### PR TITLE
Add Run AQA (Comment-Triggered PR Builds) workflow

### DIFF
--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -1,0 +1,210 @@
+name: "PR Comment Build Action for TKG"
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  parseComment:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.comment.body, 'run aqa') && github.event.issue.pull_request
+    outputs:
+      workflow_url: ${{ steps.workflow_run_info.outputs.url }}
+      workflow_id: ${{ steps.workflow_run_info.outputs.id }}
+      build_parameters: ${{ steps.argparse.outputs.build_parameters }}
+      failed: ${{ steps.failure_report.outputs.failed }} # For reportStatus to check if parseComment has already reported a failure (in parsing).
+    steps:
+    - name: Get workflow run info
+      run: |
+        echo ::set-output name=url::$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+        echo ::set-output name=id::$GITHUB_RUN_ID
+      id: workflow_run_info
+    - uses: actions/checkout@v2
+    - name: Parse parameters
+      env:
+        args: ${{ github.event.comment.body }}
+      run: python3 .github/workflows/runAqaArgParse.py $args 2> log.txt
+      id: argparse
+    - name: Output log
+      if: failure()
+      # Store the contents of log.txt into an environment variable and escape characters to preserve newlines and other symbols.
+      run: |
+        log=$(cat log.txt)
+        log="${log//'%'/'%25'}"
+        log="${log//$'\n'/'%0A'}"
+        log="${log//$'\r'/'%0D'}"
+        log="${log/$'`'/'\`'}"
+        echo ::set-output name=log::$log
+      id: output_log
+    - name: Create error comment
+      if: failure()
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          comment_body = `
+          @${{ github.actor }}
+          \`\`\`
+          ${{ steps.output_log.outputs.log }}
+          \`\`\`
+          No builds were started.
+          `;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment_body
+          })
+    - name: Failure report
+      if: failure()
+      run: echo ::set-output name=failed::true
+      id: failure_report
+    - name: Create success comment
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          comment_body = `
+          @${{ github.actor }} Build(s) started with the following parameters:
+          - sdk_resource: ${{ steps.argparse.outputs.sdk_resource }}
+          - customized_sdk_url: ${{ steps.argparse.outputs.customized_sdk_url }}
+          - archive_extension: ${{ steps.argparse.outputs.archive_extension }}
+          - build_list: ${{ steps.argparse.outputs.build_list }}
+          - target: ${{ steps.argparse.outputs.target }}
+          - platform: ${{ steps.argparse.outputs.platform }}
+          - jdk_version: ${{ steps.argparse.outputs.jdk_version }}
+          - jdk_impl: ${{ steps.argparse.outputs.jdk_impl }}
+
+          Workflow Run ID: [${{ steps.workflow_run_info.outputs.id }}](${{ steps.workflow_run_info.outputs.url }})
+          `;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment_body
+          })
+    - name: Echo parameters
+      run: |
+        echo build_parameters: ${{ steps.argparse.outputs.build_parameters }}
+        echo sdk_resource: ${{ steps.argparse.outputs.sdk_resource }}
+        echo customized_sdk_url: ${{ steps.argparse.outputs.customized_sdk_url }}
+        echo archive_extension: ${{ steps.argparse.outputs.archive_extension }}
+        echo build_list: ${{ steps.argparse.outputs.build_list }}
+        echo target: ${{ steps.argparse.outputs.target }}
+        echo platform: ${{ steps.argparse.outputs.platform }}
+        echo jdk_version: ${{ steps.argparse.outputs.jdk_version }}
+        echo jdk_impl: ${{ steps.argparse.outputs.jdk_impl }}
+
+  runBuild:
+    runs-on: ${{ matrix.platform }}
+    needs: parseComment
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.parseComment.outputs.build_parameters) }}
+    steps:
+    - uses: AdoptOpenJDK/install-jdk@v1
+      if: matrix.sdk_resource != 'customized'
+      with:
+        version: ${{ matrix.jdk_version }}
+        source: ${{ matrix.sdk_resource }}
+        sourceType: 'buildType'
+        impl: ${{ matrix.jdk_impl }}
+    - uses: AdoptOpenJDK/install-jdk@v1
+      if: matrix.sdk_resource == 'customized'
+      with:
+        version: ${{ matrix.jdk_version }}
+        source: ${{ matrix.customized_sdk_url }}
+        archiveExtension: ${{ matrix.archive_extension }}
+        sourceType: 'url'
+        impl: ${{ matrix.jdk_impl }}
+    # get-pr step by @Simran-B https://github.com/actions/checkout/issues/331#issuecomment-707103442
+    - uses: actions/github-script@v3
+      id: get-pr
+      with:
+        script: |
+          const request = {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          }
+          core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
+          try {
+            const result = await github.pulls.get(request)
+            return result.data
+          } catch (err) {
+            core.setFailed(`Request failed with error ${err}`)
+          }
+    - name: AQA
+      uses: AdoptOpenJDK/run-aqa@v1
+      with:
+         build_list: ${{ matrix.build_list }}
+         target: ${{ matrix.target }}
+         jdksource: 'install-jdk'
+         version: ${{ matrix.jdk_version }}
+         tkg_Repo: '${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}:${{ fromJSON(steps.get-pr.outputs.result).head.ref }}'
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: test_output
+        path: ./**/output_*/
+
+  reportFailure:
+    runs-on: ubuntu-latest
+    needs: [parseComment, runBuild]
+    if: failure() && !needs.parseComment.outputs.failed
+    steps:
+    - name: Create comment
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          comment_body = `
+          @${{ github.actor }} Build(s) failed.
+          Workflow Run ID: [${{ needs.parseComment.outputs.workflow_id }}](${{ needs.parseComment.outputs.workflow_url }})
+          `;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment_body
+          })
+
+  reportCancelled:
+    runs-on: ubuntu-latest
+    needs: [parseComment, runBuild]
+    if: cancelled()
+    steps:
+    - name: Create comment
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          comment_body = `
+          @${{ github.actor }} Build(s) cancelled.
+          Workflow Run ID: [${{ needs.parseComment.outputs.workflow_id }}](${{ needs.parseComment.outputs.workflow_url }})
+          `;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment_body
+          })
+
+  reportSuccess:
+    runs-on: ubuntu-latest
+    needs: [parseComment, runBuild]
+    if: success()
+    steps:
+    - name: Create comment
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          comment_body = `
+          @${{ github.actor }} Build(s) successful.
+          Workflow Run ID: [${{ needs.parseComment.outputs.workflow_id }}](${{ needs.parseComment.outputs.workflow_url }})
+          `;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment_body
+          })

--- a/.github/workflows/runAqaArgParse.py
+++ b/.github/workflows/runAqaArgParse.py
@@ -1,0 +1,78 @@
+import argparse
+import json
+import sys
+
+def map_platforms(platforms):
+    """ Takes in a list of platforms and translates Grinder platorms to corresponding GitHub-hosted runners.
+        This function both modifies and returns the 'platforms' argument.
+    """
+    
+    platform_map = {
+        'x86-64_windows': 'windows-latest',
+        'x86-64_mac': 'macos-latest',
+        'x86-64_linux': 'ubuntu-latest'
+    }
+    
+    for i, platform in enumerate(platforms):
+        if platform in platform_map:
+            platforms[i] = platform_map[platform]
+    
+    return platforms
+
+def underscore_targets(targets):
+    """ Takes in a list of targets and prefixes them with an underscore if they do not have one.
+    """
+    result = []
+    for target in targets:
+        t = target
+        if target[0] != '_':
+            t = '_' + t
+        result.append(t)
+    return result
+
+def main():
+
+    # The keyword for this command.
+    keyword = 'run aqa'
+    keywords = keyword.split()
+
+    # We assume that the first argument is/are the keyword(s).
+    # e.g. sys.argv == ['action_argparse.py', 'run', 'aqa', ...]
+    raw_args = sys.argv[1 + len(keywords):]
+
+    # Strip leading and trailing whitespace. Remove empty arguments that may result after stripping.
+    raw_args = list(filter(lambda empty: empty, map(lambda s: s.strip(), raw_args)))
+
+    parser = argparse.ArgumentParser(prog=keyword, add_help=False)
+    # Improvement: Automatically resolve the valid choices for each argument populate them below, rather than hard-coding choices.
+    parser.add_argument('--sdk_resource', default=['nightly'], choices=['nightly', 'releases', 'customized'], nargs='+')
+    parser.add_argument('--customized_sdk_url', default=['None'], nargs='+')
+    parser.add_argument('--archive_extension', default=['.tar'], choices=['.zip', '.tar', '.7z'], nargs='+')
+    parser.add_argument('--build_list', default=['openjdk'], choices=['openjdk', 'functional', 'system', 'perf', 'external'], nargs='+')
+    parser.add_argument('--target', default=['_jdk_math'], nargs='+')
+    parser.add_argument('--platform', default=['x86-64_linux'], nargs='+')
+    parser.add_argument('--jdk_version', default=['8'], nargs='+')
+    parser.add_argument('--jdk_impl', default=['openj9'], choices=['hotspot', 'openj9'], nargs='+')
+    args = vars(parser.parse_args(raw_args))
+    # All args are lists of strings
+
+    # Map grinder platform names to github runner names
+    args['platform'] = map_platforms(args['platform'])
+
+    # Underscore the targets if necessary
+    args['target'] = underscore_targets(args['target'])
+
+    # If 'customized' sdk_resource, then customized_sdk_url and archive_extension must be present.
+    if 'customized' in args['sdk_resource'] and args['customized_sdk_url'] == ['None']:
+        err_msg = '--customized_sdk_url must be provided if sdk_resource is set to customized.'
+        print('::error ::{}'.format(err_msg))
+        sys.stderr.write(err_msg)
+        exit(2)
+
+    # Output the arguments
+    print('::set-output name=build_parameters::{}'.format(json.dumps(args)))
+    for key, value in args.items():
+        print('::set-output name={}::{}'.format(key, value))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
As per AdoptOpenJDK/openjdk-tests#2399, adds the Run AQA (Comment-Triggered PR Builds) workflow to the TKG repo.
When ran on a PR in this (TKG) repo, the [AdoptOpenJDK/run-aqa@v1](https://github.com/AdoptOpenJDK/run-aqa) GitHub action is ran with the `tkg_Repo` argument set to the head of the PR.