### PR TITLE
Add configuration file and custom openjdk-test repo option to Run AQA workflow

### DIFF
--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -17,11 +17,22 @@ jobs:
         echo ::set-output name=url::$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
         echo ::set-output name=id::$GITHUB_RUN_ID
       id: workflow_run_info
-    - uses: actions/checkout@v2
+    # Checkout current repo to access the repo-specific config file `.github/workflows/runAqaConfig.json`
+    - name: Checkout current repo
+      uses: actions/checkout@v2
+      with:
+        path: 'main'
+    # Checkout the main TKG repo to access the shared script `scripts/testRepo/runAqaArgParse.py`
+    - name: Checkout main TKG repo
+      uses: actions/checkout@v2
+      with:
+        repository: 'adoptium/TKG.git'
+        ref: 'master'
+        path: 'TKG'
     - name: Parse parameters
       env:
         args: ${{ github.event.comment.body }}
-      run: python3 .github/workflows/runAqaArgParse.py $args 2> log.txt
+      run: python3 TKG/scripts/testBot/runAqaArgParse.py $args 2> log.txt
       id: argparse
     - name: Output log
       if: failure()

--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -72,6 +72,7 @@ jobs:
           - platform: ${{ steps.argparse.outputs.platform }}
           - jdk_version: ${{ steps.argparse.outputs.jdk_version }}
           - jdk_impl: ${{ steps.argparse.outputs.jdk_impl }}
+          - openjdk_testrepo: ${{ steps.argparse.outputs.openjdk_testrepo }}
 
           Workflow Run ID: [${{ steps.workflow_run_info.outputs.id }}](${{ steps.workflow_run_info.outputs.url }})
           `;
@@ -92,6 +93,7 @@ jobs:
         echo platform: ${{ steps.argparse.outputs.platform }}
         echo jdk_version: ${{ steps.argparse.outputs.jdk_version }}
         echo jdk_impl: ${{ steps.argparse.outputs.jdk_impl }}
+        echo openjdk_testrepo: ${{ steps.argparse.outputs.openjdk_testrepo }}
 
   runBuild:
     runs-on: ${{ matrix.platform }}
@@ -139,6 +141,7 @@ jobs:
          target: ${{ matrix.target }}
          jdksource: 'install-jdk'
          version: ${{ matrix.jdk_version }}
+         openjdk_testRepo: ${{ matrix.openjdk_testrepo }}
          tkg_Repo: '${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}:${{ fromJSON(steps.get-pr.outputs.result).head.ref }}'
     - uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -146,7 +146,7 @@ jobs:
             core.setFailed(`Request failed with error ${err}`)
           }
     - name: AQA
-      uses: AdoptOpenJDK/run-aqa@v1
+      uses: adoptium/run-aqa@v1
       with:
          build_list: ${{ matrix.build_list }}
          target: ${{ matrix.target }}

--- a/.github/workflows/runAqaArgParse.py
+++ b/.github/workflows/runAqaArgParse.py
@@ -53,6 +53,7 @@ def main():
     parser.add_argument('--platform', default=['x86-64_linux'], nargs='+')
     parser.add_argument('--jdk_version', default=['8'], nargs='+')
     parser.add_argument('--jdk_impl', default=['openj9'], choices=['hotspot', 'openj9'], nargs='+')
+    parser.add_argument('--openjdk_testrepo', default=['AdoptOpenJDK/openjdk-tests'], nargs='+')
     args = vars(parser.parse_args(raw_args))
     # All args are lists of strings
 

--- a/.github/workflows/runAqaConfig.json
+++ b/.github/workflows/runAqaConfig.json
@@ -1,0 +1,4 @@
+{
+    "custom_openjdk_testrepo": true,
+    "custom_tkg_repo": false
+}

--- a/scripts/testBot/runAqaArgParse.py
+++ b/scripts/testBot/runAqaArgParse.py
@@ -53,7 +53,15 @@ def main():
     parser.add_argument('--platform', default=['x86-64_linux'], nargs='+')
     parser.add_argument('--jdk_version', default=['8'], nargs='+')
     parser.add_argument('--jdk_impl', default=['openj9'], choices=['hotspot', 'openj9'], nargs='+')
-    parser.add_argument('--openjdk_testrepo', default=['AdoptOpenJDK/openjdk-tests'], nargs='+')
+
+    # Custom repo options which may be enabled/disabled in the `runAqaConfig.json` file.
+    with open('main/.github/workflows/runAqaConfig.json') as f:
+        config = json.load(f)
+        if config['custom_openjdk_testrepo']:
+            parser.add_argument('--openjdk_testrepo', default=['AdoptOpenJDK/openjdk-tests'], nargs='+')
+        if config['custom_tkg_repo']:
+            parser.add_argument('--tkg_repo', default=['adoptium/TKG:master'], nargs='+')
+
     args = vars(parser.parse_args(raw_args))
     # All args are lists of strings
 


### PR DESCRIPTION
Builds on top of PR #170 

Move the `runAqaArgParse.py` into `scripts/testBot` as a common place to not duplicate the code for multiple repos (as suggested by @renfeiw)

Add a configuration file `.github/workflows/runAqaConfig.json` for repository-specific defaults (as suggested by @smlambert). Currently only enables/disables arguments for custom TKG and openjdk-tests repos. Can be amended with more options later down the line as needed.

Change the AdoptOpenJDK/run-aqa@v1 action to [adoptium/run-aqa@v1](https://github.com/adoptium/run-aqa). Simply a renaming, no change in functionality.

Add the option to specify a custom openjdk-tests repo to pass to the [adoptium/run-aqa@v1](https://github.com/adoptium/run-aqa) action which is used to run AQA.

**Note for testing**: The `runAqaArgParse.py` script is expected to be in this repository on the master branch (adoptium/TKG:master), but does not yet exist because this PR has not been merged. Therefore, for testing, [line 29 of `runAqa.yml`](https://github.com/adoptium/TKG/pull/172/files#diff-e0dd7944dfde8fbe2467c4703a07669ee4d9a80e663921f6585ff0c4134f7d45R29) should be changed match your/my personal repo which has the `runAqaArgParse.py` script in the correct location (`scripts/testBot`)
