### PR TITLE
Add help command for a link to documentation in the Run AQA workflow

### DIFF
--- a/scripts/testBot/runAqaArgParse.py
+++ b/scripts/testBot/runAqaArgParse.py
@@ -79,6 +79,8 @@ Click the above link to view the documentation for the Run AQA GitHub Workflow''
         sys.stderr.write(help_msg)
         print('::error ::Help command invoked')
         exit(2)
+    # Remove help flag from the args because it is not a parameter for the job matrix.
+    del args['help']
 
     # Map grinder platform names to github runner names
     args['platform'] = map_platforms(args['platform'])

--- a/scripts/testBot/runAqaArgParse.py
+++ b/scripts/testBot/runAqaArgParse.py
@@ -45,6 +45,7 @@ def main():
 
     parser = argparse.ArgumentParser(prog=keyword, add_help=False)
     # Improvement: Automatically resolve the valid choices for each argument populate them below, rather than hard-coding choices.
+    parser.add_argument('--help', '-h', action='store_true')
     parser.add_argument('--sdk_resource', default=['nightly'], choices=['nightly', 'releases', 'customized'], nargs='+')
     parser.add_argument('--customized_sdk_url', default=['None'], nargs='+')
     parser.add_argument('--archive_extension', default=['.tar'], choices=['.zip', '.tar', '.7z'], nargs='+')
@@ -64,6 +65,20 @@ def main():
 
     args = vars(parser.parse_args(raw_args))
     # All args are lists of strings
+
+    # Help was requested. The simplest way to handle this is as if it were an error
+    # because stdout is reserved for workflow commands and logs.
+    if args['help']:
+        # For some unknown reason, the first tilde in this help message should not be escaped,
+        # otherwise a syntax error occurs when passed to the GitHub Script.
+        help_msg = '''Run AQA GitHub Action Documentation
+`\\`\\`
+https://github.com/AdoptOpenJDK/openjdk-tests/blob/master/doc/RunAqa.md
+\\`\\`\\`
+Click the above link to view the documentation for the Run AQA GitHub Workflow'''
+        sys.stderr.write(help_msg)
+        print('::error ::Help command invoked')
+        exit(2)
 
     # Map grinder platform names to github runner names
     args['platform'] = map_platforms(args['platform'])


### PR DESCRIPTION
Add a `--help` / `-h` argument to the Run AQA workflow (#170) which links to its documentation: 
https://github.com/AdoptOpenJDK/openjdk-tests/blob/master/doc/RunAqa.md

![image](https://user-images.githubusercontent.com/5418647/113795940-41d75e80-970b-11eb-849b-05827debdffe.png)

This PR implements the same functionality of AdoptOpenJDK/openjdk-tests#2457

**Note for testing**: This PR changes `runAqaArgParse.py` but the workflow will continue to use the unchanged `runAqaArgParse.py` from `adoptium:master`. Therefore, for testing, [line 29 of `runAqa.yml`](https://github.com/adoptium/TKG/blob/master/.github/workflows/runAqa.yml#L29) should be changed to match your/my personal repo which has the updated `runAqaArgParse.py`.