### PR TITLE
Fix default value for openjdk_testrepo in Run AQA workflow script

### DIFF
--- a/scripts/testBot/runAqaArgParse.py
+++ b/scripts/testBot/runAqaArgParse.py
@@ -58,7 +58,7 @@ def main():
     with open('main/.github/workflows/runAqaConfig.json') as f:
         config = json.load(f)
         if config['custom_openjdk_testrepo']:
-            parser.add_argument('--openjdk_testrepo', default=['AdoptOpenJDK/openjdk-tests'], nargs='+')
+            parser.add_argument('--openjdk_testrepo', default=['AdoptOpenJDK/openjdk-tests:master'], nargs='+')
         if config['custom_tkg_repo']:
             parser.add_argument('--tkg_repo', default=['adoptium/TKG:master'], nargs='+')
 


### PR DESCRIPTION
The previous default value for `--openjdk_testrepo` did not include a branch and therefore was invalid, which caused builds using the default openjdk_testrepo to fail.

**Note for testing**: This PR changes `runAqaArgParse.py` but the workflow will continue to use the unchanged `runAqaArgParse.py` from `adoptium:master`. Therefore, for testing, [line 29 of `runAqa.yml`](https://github.com/adoptium/TKG/blob/master/.github/workflows/runAqa.yml#L29) should be changed to match your/my personal repo which has the updated `runAqaArgParse.py`.