### PR TITLE
Run AQA Workflow: Implement build-jdk sdk_resource, Remove redundant checkouts

### DIFF
--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -17,22 +17,15 @@ jobs:
         echo ::set-output name=url::$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
         echo ::set-output name=id::$GITHUB_RUN_ID
       id: workflow_run_info
-    # Checkout current repo to access the repo-specific config file `.github/workflows/runAqaConfig.json`
+    # Checkout current (TKG) repo to access the repo-specific config file `.github/workflows/runAqaConfig.json` and the shared script `scripts/testRepo/runAqaArgParse.py`
     - name: Checkout current repo
       uses: actions/checkout@v2
       with:
         path: 'main'
-    # Checkout the main TKG repo to access the shared script `scripts/testRepo/runAqaArgParse.py`
-    - name: Checkout main TKG repo
-      uses: actions/checkout@v2
-      with:
-        repository: 'adoptium/TKG.git'
-        ref: 'master'
-        path: 'TKG'
     - name: Parse parameters
       env:
         args: ${{ github.event.comment.body }}
-      run: python3 TKG/scripts/testBot/runAqaArgParse.py $args 2> log.txt
+      run: python3 main/scripts/testBot/runAqaArgParse.py $args 2> log.txt
       id: argparse
     - name: Output log
       if: failure()

--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -76,6 +76,7 @@ jobs:
           comment_body = `
           @${{ github.actor }} Build(s) started with the following parameters:
           - sdk_resource: ${{ steps.argparse.outputs.sdk_resource }}
+          - build_repo: ${{ steps.argparse.outputs.build_repo }}
           - customized_sdk_url: ${{ steps.argparse.outputs.customized_sdk_url }}
           - archive_extension: ${{ steps.argparse.outputs.archive_extension }}
           - build_list: ${{ steps.argparse.outputs.build_list }}
@@ -93,18 +94,9 @@ jobs:
             repo: context.repo.repo,
             body: comment_body
           })
-    - name: Echo parameters
+    - name: Echo all parameters
       run: |
-        echo build_parameters: ${{ steps.argparse.outputs.build_parameters }}
-        echo sdk_resource: ${{ steps.argparse.outputs.sdk_resource }}
-        echo customized_sdk_url: ${{ steps.argparse.outputs.customized_sdk_url }}
-        echo archive_extension: ${{ steps.argparse.outputs.archive_extension }}
-        echo build_list: ${{ steps.argparse.outputs.build_list }}
-        echo target: ${{ steps.argparse.outputs.target }}
-        echo platform: ${{ steps.argparse.outputs.platform }}
-        echo jdk_version: ${{ steps.argparse.outputs.jdk_version }}
-        echo jdk_impl: ${{ steps.argparse.outputs.jdk_impl }}
-        echo openjdk_testrepo: ${{ steps.argparse.outputs.openjdk_testrepo }}
+        echo ${{ steps.argparse.outputs.build_parameters }}
 
   runBuild:
     runs-on: ${{ matrix.platform }}
@@ -114,12 +106,25 @@ jobs:
       matrix: ${{ fromJson(needs.parseComment.outputs.build_parameters) }}
     steps:
     - uses: AdoptOpenJDK/install-jdk@v1
-      if: matrix.sdk_resource != 'customized'
+      if: matrix.sdk_resource == 'nightly' || matrix.sdk_resource == 'releases'
       with:
         version: ${{ matrix.jdk_version }}
         source: ${{ matrix.sdk_resource }}
         sourceType: 'buildType'
         impl: ${{ matrix.jdk_impl }}
+    - name: Checkout PR Ref
+      uses: actions/checkout@v2
+      if: matrix.sdk_resource == 'build-jdk'
+      with:
+        repository: ${{ matrix.build_repo_branch.repo }}
+        ref: ${{ matrix.build_repo_branch.branch }}
+        path: 'openjdk-build'
+    - uses: AdoptOpenJDK/build-jdk@v1
+      if: matrix.sdk_resource == 'build-jdk'
+      with:
+        javaToBuild: jdk${{ matrix.jdk_version }}u
+        impl: ${{ matrix.jdk_impl }}
+        usePRRef: true # usePRRef=true will cause build-jdk to use the existing openjdk-build/ directory > See https://github.com/AdoptOpenJDK/build-jdk/issues/24#issuecomment-816322945
     - uses: AdoptOpenJDK/install-jdk@v1
       if: matrix.sdk_resource == 'customized'
       with:


### PR DESCRIPTION
This PR builds on top of #170: Run AQA (Comment-Triggered PR Build) workflow

- Change the `Echo parameters` step to simply echo the entire JSON of build parameters instead of each individual value in addition to it.

- Reduce redundant checkouts by using the fact that the current repo is the TKG repo. This also removes the need to modify the TKG checkout action to test changes to `runAqaArgParse.py`.

- Implement a new sdk_resource `build-jdk` which uses the [AdoptOpenJDK/build-jdk](https://github.com/AdoptOpenJDK/build-jdk/) action to build a JDK using a provided openjdk-build repo.

This functionality was requested in issue https://github.com/AdoptOpenJDK/openjdk-tests/issues/2296 but was blocked due to issue https://github.com/AdoptOpenJDK/build-jdk/issues/24 which is still unresolved, but has a (unintended?) workaround that works due to the `usePRRef` input not causing the action to pull from the PR ref but instead have the action use whatever existing `openjdk-build` directory is in the workspace (if any).

The same workaround does not work for the [eclipse-openj9/build-openj9](https://github.com/eclipse-openj9/build-openj9) action because its similarly-named `usePersonalRepo` input does checkout the PR ref and also does not accept a custom repo and branch input (https://github.com/eclipse-openj9/build-openj9/issues/18), so the action would need to be rewritten.

Example run: [734853617](https://github.com/Icohedron/TKG/actions/runs/734853617)
![image](https://user-images.githubusercontent.com/5418647/114255688-12765b00-9972-11eb-801e-9f36c3ca2893.png)


