### PR TITLE
Update getDependencies.pl to move download jtreg.jar logic in getDependencies

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -131,14 +131,14 @@ my %base = (
 	},
 	jtreg_4_2_0_tip => {
 		url => 'https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-4.2.0-tip.tar.gz',
-		fname => 'jtreg-4.2.0-tip.tar.gz',
+		fname => 'jtreg_4_2_0_tip.tar.gz',
 		shaurl => 'https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-4.2.0-tip.tar.gz.sha256sum.txt',
 		shafn => 'jtreg-4.2.0-tip.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
 	jtreg_5_1_b01 => {
 		url => 'https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-5.1-b01.tar.gz',
-		fname => 'jtreg-5.1-b01.tar.gz',
+		fname => 'jtreg_5_1_b01.tar.gz',
 		shaurl => 'https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-5.1-b01.tar.gz.sha256sum.txt',
 		shafn => 'jtreg-5.1-b01.tar.gz.sha256sum.txt',
 		shaalg => '256'

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -129,11 +129,18 @@ my %base = (
 		fname => 'org.eclipse.osgi-3.16.100.jar',
 		sha1 => '7ddb312f386b799d6e004d193a01c50169bf69f3'
 	},
-	jtreg => {
-		url => "https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/$jtregVersion.tar.gz",
+	jtreg-4.2.0-tip.tar => {
+		url => "https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-4.2.0-tip.tar.gz",
 		fname => 'jtreg.tar.gz',
-		shaurl => "https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/$jtregVersion.tar.gz.sha256sum.txt",
-		shafn => "$jtregVersion.tar.gz.sha256sum.txt",
+		shaurl => "https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-4.2.0-tip.tar.gz.sha256sum.txt",
+		shafn => "jtreg-4.2.0-tip.tar.gz.sha256sum.txt",
+		shaalg => '256'
+	},
+	jtreg-5.1-b01.tar => {
+		url => "https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-5.1-b01.tar.gz",
+		fname => 'jtreg.tar.gz',
+		shaurl => "https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-5.1-b01.tar.gz.sha256sum.txt",
+		shafn => "jtreg-5.1-b01.tar.gz.sha256sum.txt",
 		shaalg => '256'
 	},
 	jython => {

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -129,6 +129,13 @@ my %base = (
 		fname => 'org.eclipse.osgi-3.16.100.jar',
 		sha1 => '7ddb312f386b799d6e004d193a01c50169bf69f3'
 	},
+	jtreg => {
+		url => "https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/$jtregVersion.tar.gz",
+		fname => 'jtreg.tar.gz',
+		shaurl => "https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/$jtregVersion.tar.gz.sha256sum.txt",
+		shafn => "$jtregVersion.tar.gz.sha256sum.txt",
+		shaalg => '256'
+	},
 	jython => {
 		url => 'https://repo1.maven.org/maven2/org/python/jython-standalone/2.7.2/jython-standalone-2.7.2.jar',
 		fname => 'jython-standalone.jar',

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -129,14 +129,14 @@ my %base = (
 		fname => 'org.eclipse.osgi-3.16.100.jar',
 		sha1 => '7ddb312f386b799d6e004d193a01c50169bf69f3'
 	},
-	jtreg-4.2.0-tip => {
+	jtreg_4_2_0_tip => {
 		url => 'https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-4.2.0-tip.tar.gz',
 		fname => 'jtreg-4.2.0-tip.tar.gz',
 		shaurl => 'https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-4.2.0-tip.tar.gz.sha256sum.txt',
 		shafn => 'jtreg-4.2.0-tip.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
-	jtreg-5.1-b01 => {
+	jtreg_5_1_b01 => {
 		url => 'https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-5.1-b01.tar.gz',
 		fname => 'jtreg-5.1-b01.tar.gz',
 		shaurl => 'https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-5.1-b01.tar.gz.sha256sum.txt',

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -129,18 +129,18 @@ my %base = (
 		fname => 'org.eclipse.osgi-3.16.100.jar',
 		sha1 => '7ddb312f386b799d6e004d193a01c50169bf69f3'
 	},
-	jtreg-4.2.0-tip.tar => {
-		url => "https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-4.2.0-tip.tar.gz",
-		fname => 'jtreg.tar.gz',
-		shaurl => "https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-4.2.0-tip.tar.gz.sha256sum.txt",
-		shafn => "jtreg-4.2.0-tip.tar.gz.sha256sum.txt",
+	jtreg-4.2.0-tip => {
+		url => 'https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-4.2.0-tip.tar.gz',
+		fname => 'jtreg-4.2.0-tip.tar.gz',
+		shaurl => 'https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-4.2.0-tip.tar.gz.sha256sum.txt',
+		shafn => 'jtreg-4.2.0-tip.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
-	jtreg-5.1-b01.tar => {
-		url => "https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-5.1-b01.tar.gz",
-		fname => 'jtreg.tar.gz',
-		shaurl => "https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-5.1-b01.tar.gz.sha256sum.txt",
-		shafn => "jtreg-5.1-b01.tar.gz.sha256sum.txt",
+	jtreg-5.1-b01 => {
+		url => 'https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-5.1-b01.tar.gz',
+		fname => 'jtreg-5.1-b01.tar.gz',
+		shaurl => 'https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-5.1-b01.tar.gz.sha256sum.txt',
+		shafn => 'jtreg-5.1-b01.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
 	jython => {


### PR DESCRIPTION
I have added the suggested section in the getDependencies.pl file and removed the download jtreg.jar logic from the build.xml file. Please review both the pull request made for [issue](https://github.com/AdoptOpenJDK/openjdk-tests/issues/2484).