### PR TITLE
Edited the runAqaArgParse.py file

### DIFF
--- a/scripts/testBot/runAqaArgParse.py
+++ b/scripts/testBot/runAqaArgParse.py
@@ -3,8 +3,8 @@ import json
 import sys
 import os
 
-dir_list = next(os.walk('.'))[1]
-files = map(lambda str : "external/"+str, dir_list);
+dirList = next(os.walk('.'))[1]
+files = map(lambda str : "external/"+str, dirList);
 allFiles = list(files)
 
 def map_platforms(platforms):

--- a/scripts/testBot/runAqaArgParse.py
+++ b/scripts/testBot/runAqaArgParse.py
@@ -1,22 +1,27 @@
 import argparse
 import json
 import sys
+import os
+
+dir_list = next(os.walk('.'))[1]
+files = map(lambda str : "external/"+str, dir_list);
+allFiles = list(files)
 
 def map_platforms(platforms):
     """ Takes in a list of platforms and translates Grinder platorms to corresponding GitHub-hosted runners.
         This function both modifies and returns the 'platforms' argument.
     """
-    
+
     platform_map = {
         'x86-64_windows': 'windows-latest',
         'x86-64_mac': 'macos-latest',
         'x86-64_linux': 'ubuntu-latest'
     }
-    
+
     for i, platform in enumerate(platforms):
         if platform in platform_map:
             platforms[i] = platform_map[platform]
-    
+
     return platforms
 
 def underscore_targets(targets):
@@ -49,7 +54,7 @@ def main():
     parser.add_argument('--sdk_resource', default=['nightly'], choices=['nightly', 'releases', 'customized'], nargs='+')
     parser.add_argument('--customized_sdk_url', default=['None'], nargs='+')
     parser.add_argument('--archive_extension', default=['.tar'], choices=['.zip', '.tar', '.7z'], nargs='+')
-    parser.add_argument('--build_list', default=['openjdk'], choices=['openjdk', 'functional', 'system', 'perf', 'external'], nargs='+')
+    parser.add_argument('--build_list', default=['openjdk'], choices=['openjdk', 'functional', 'system', 'perf', allFiles], nargs='+')
     parser.add_argument('--target', default=['_jdk_math'], nargs='+')
     parser.add_argument('--platform', default=['x86-64_linux'], nargs='+')
     parser.add_argument('--jdk_version', default=['8'], nargs='+')


### PR DESCRIPTION
Instead of hardcoding each subdir in the list, I have made a function that queries the contents of external and creates a list of acceptable build_list values.

Fixes [#2482](https://github.com/AdoptOpenJDK/openjdk-tests/issues/2482)