### PR TITLE
Add platformMap for x86-64_solaris

### DIFF
--- a/resources/buildPlatformMap.properties
+++ b/resources/buildPlatformMap.properties
@@ -39,6 +39,7 @@ osx_x86-64=x86-64_mac_xl
 osx_x86-64_cmprssptrs=x86-64_mac
 osx_x86-64_mxdptrs=x86-64_mac_mixed
 sunos_sparcv9-64=sparcv9_solaris
+sunos_x86-64=x86-64_solaris
 win_x86-64=x86-64_windows_xl
 win_x86-64_cmprssptrs=x86-64_windows
 win_x86-64_mxdptrs=x86-64_windows_mixed


### PR DESCRIPTION
fixes:

```output
20:52:00  Exception in thread "main" java.lang.NullPointerException
20:52:00  	at java.util.regex.Matcher.getTextLength(Matcher.java:1283)
20:52:00  	at java.util.regex.Matcher.reset(Matcher.java:309)
20:52:00  	at java.util.regex.Matcher.<init>(Matcher.java:229)
20:52:00  	at java.util.regex.Pattern.matcher(Pattern.java:1093)
20:52:00  	at org.testKitGen.TestInfoParser.checkPlat(TestInfoParser.java:226)
20:52:00  	at org.testKitGen.TestInfoParser.parseVariation(TestInfoParser.java:295)
20:52:00  	at org.testKitGen.TestInfoParser.parse(TestInfoParser.java:93)
20:52:00  	at org.testKitGen.PlaylistInfoParser.parse(PlaylistInfoParser.java:106)
20:52:00  	at org.testKitGen.ParallelGenVisitor.visit(ParallelGenVisitor.java:34)
20:52:00  	at org.testKitGen.DirectoryWalker.traverse(DirectoryWalker.java:77)
20:52:00  	at org.testKitGen.DirectoryWalker.traverse(DirectoryWalker.java:70)
20:52:00  	at org.testKitGen.DirectoryWalker.traverse(DirectoryWalker.java:70)
20:52:00  	at org.testKitGen.MainRunner.genParallelList(MainRunner.java:54)
20:52:00  	at org.testKitGen.MainRunner.main(MainRunner.java:34)
```