### PR TITLE
Ensure TestInfoParser gets correct platform element

### DIFF
--- a/src/org/testKitGen/TestInfoParser.java
+++ b/src/org/testKitGen/TestInfoParser.java
@@ -77,7 +77,15 @@ public class TestInfoParser {
 
 		NodeList platNodes = testEle.getElementsByTagName("platform");
 		if (platNodes.getLength() > 0) {
-			ti.setPlatform(platNodes.item(0).getTextContent().trim());
+			// Ensure we only get the <test>-><platform> node and not <test>-><disabled>-><platform> nodes
+                        for (int i = 0; i < platNodes.getLength(); i++) {
+                                Node platNode = platNodes.item(i);
+				if (platNode.getParentNode().isSameNode(testEle)) {
+					// Found <test>-><platform> node
+					ti.setPlatform(platNode.getTextContent().trim());
+					break;
+				}
+			}
 		}
 
 		NodeList preqNodes = testEle.getElementsByTagName("platformRequirements");


### PR DESCRIPTION
getElementsByTagName("platform") returns all platform nodes in the document including child ones from any <disabled> sections. This PR finds the <platform> element that is directly within the parent element. 

Signed-off-by: Andrew Leonard <anleonar@redhat.com>