### PR TITLE
Allow other jenkins parameters to show in Grinder re-run console links

### DIFF
--- a/resources/buildPlatformMap.properties
+++ b/resources/buildPlatformMap.properties
@@ -10,6 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NOTE: These mappings are used exclusively for the "Re-run in Grinder"
+#       links in the console log output
+
 aix_ppc-64_nocmprssptrs=ppc64_aix_xl
 aix_ppc-64_cmprssptrs=ppc64_aix_cmprssptrs
 aix_ppc-64=ppc64_aix
@@ -21,7 +24,7 @@ linux_390=s390_linux
 linux_aarch64_nocmprssptrs=aarch64_linux_xl
 linux_aarch64_cmprssptrs=aarch64_linux_cmprssptrs
 linux_aarch64=aarch64_linux
-linux_arm=aarch32_linux
+linux_arm=arm_linux
 linux_ppc-64_nocmprssptrs=ppc64_linux_xl
 linux_ppc-64_cmprssptrs=ppc64_linux_cmprssptrs
 linux_ppc-64_cmprssptrs_le=ppc64le_linux_cmprssptrs

--- a/resources/buildPlatformMap.properties
+++ b/resources/buildPlatformMap.properties
@@ -10,9 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# NOTE: These mappings are used exclusively for the "Re-run in Grinder"
-#       links in the console log output
-
 aix_ppc-64_nocmprssptrs=ppc64_aix_xl
 aix_ppc-64_cmprssptrs=ppc64_aix_cmprssptrs
 aix_ppc-64=ppc64_aix

--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -250,8 +250,6 @@ sub resultReporter {
 		my $platformParam = "";
 		if (exists $spec2platform->{$spec}) {
 			$platformParam = "&PLATFORM=" . $spec2platform->{$spec};
-			# spec fileuses aarch32, but Grinder needs arm as the parameter
-			$platformParam =~ 's/aarch32_/arm_/';
 		}
 		my $customTargetParam = "";
 		if ($customTarget ne '') {

--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -263,6 +263,8 @@ sub resultReporter {
 		if ($jdkVendor ne '') {
 			$vendorParam = "&JDK_VENDOR=" . $jdkVendor;
 		}
+		# TODO: Revisit this and make it more generic and allow all potentially
+		#       applicaable Grinder job paramers to be made availablea
 		my $jenkinsParam = "";
 		if ( defined $ENV{'JCK_GIT_REPO'} ) {
 			$jenkinsParam .= "&JCK_GIT_REPO="        . $ENV{'JCK_GIT_REPO'};

--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -264,7 +264,7 @@ sub resultReporter {
 			$vendorParam = "&JDK_VENDOR=" . $jdkVendor;
 		}
 		# TODO: Revisit this and make it more generic and allow all potentially
-		#       applicaable Grinder job paramers to be made availablea
+		#       applicable Grinder job parameters to be made available
 		my $jenkinsParam = "";
 		if ( defined $ENV{'JCK_GIT_REPO'} ) {
 			$jenkinsParam .= "&JCK_GIT_REPO="        . $ENV{'JCK_GIT_REPO'};

--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -250,6 +250,8 @@ sub resultReporter {
 		my $platformParam = "";
 		if (exists $spec2platform->{$spec}) {
 			$platformParam = "&PLATFORM=" . $spec2platform->{$spec};
+			# spec fileuses aarch32, but Grinder needs arm as the parameter
+			$platformParam =~ 's/aarch32_/arm_/';
 		}
 		my $customTargetParam = "";
 		if ($customTarget ne '') {
@@ -263,11 +265,31 @@ sub resultReporter {
 		if ($jdkVendor ne '') {
 			$vendorParam = "&JDK_VENDOR=" . $jdkVendor;
 		}
+		my $jenkinsParam = "";
+		if ($ENV{'JCK_GIT_REPO'} ne '') {
+			$jenkinsParam .= "&JCK_GIT_REPO="        . $ENV{'JCK_GIT_REPO'};
+		}
+		if ($ENV{'SDK_RESOURCE'} ne '') {
+			$jenkinsParam .= "&SDK_RESOURCE="        . $ENV{'SDK_RESOURCE'};
+		}
+		if ($ENV{'CUSTOMIZED_SDK_URL'} ne '') {
+			$jenkinsParam .= "&CUSTOMIZED_SDK_URL="  . $ENV{'CUSTOMIZED_SDK_URL'};
+		}
+		if ($ENV{'CUSTOMIZED_SDK_URL_CREDENTIAL_ID'} ne '') {
+			$jenkinsParam .= "&CUSTOMIZED_SDK_URL_CREDENTIAL_ID=" . $ENV{'CUSTOMIZED_SDK_URL_CREDENTIAL_ID'};
+		}
+		if ($ENV{'UPSTREAM_JOB_NAME'} ne '') {
+			$jenkinsParam .= "&UPSTREAM_JOB_NAME="   . $ENV{'UPSTREAM_JOB_NAME'};
+		}
+		if ($ENV{'UPSTREAM_JOB_NUMBER'} ne '') {
+			$jenkinsParam .= "&UPSTREAM_JOB_NUMBER=" . $ENV{'UPSTREAM_JOB_NUMBER'};
+		}
 
-		my $rebuildLinkBase = "parambuild/?JDK_VERSION=$jdkVersion&JDK_IMPL=$jdkImpl$vendorParam$buildParam$platformParam$customTargetParam";
+		my $rebuildLinkBase = "parambuild/?JDK_VERSION=$jdkVersion&JDK_IMPL=$jdkImpl$vendorParam$buildParam$platformParam$customTargetParam$jenkinsParam";
 		print "To rebuild the failed test in a jenkins job, copy the following link and fill out the <Jenkins URL> and <FAILED test target>:\n";
 		print "<Jenkins URL>/$rebuildLinkBase&TARGET=<FAILED test target>\n\n";
 		print "For example, to rebuild the failed tests in <Jenkins URL>=${hudsonUrl}job/Grinder, use the following links:\n";
+
 		foreach my $failedTarget (@failed) {
 			print "${hudsonUrl}job/Grinder/$rebuildLinkBase&TARGET=$failedTarget\n";
 		}

--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -266,22 +266,22 @@ sub resultReporter {
 			$vendorParam = "&JDK_VENDOR=" . $jdkVendor;
 		}
 		my $jenkinsParam = "";
-		if ($ENV{'JCK_GIT_REPO'} ne '') {
+		if ( defined $ENV{'JCK_GIT_REPO'} ) {
 			$jenkinsParam .= "&JCK_GIT_REPO="        . $ENV{'JCK_GIT_REPO'};
 		}
-		if ($ENV{'SDK_RESOURCE'} ne '') {
+		if ( defined $ENV{'SDK_RESOURCE'} ) {
 			$jenkinsParam .= "&SDK_RESOURCE="        . $ENV{'SDK_RESOURCE'};
 		}
-		if ($ENV{'CUSTOMIZED_SDK_URL'} ne '') {
+		if ( defined $ENV{'CUSTOMIZED_SDK_URL'} ) {
 			$jenkinsParam .= "&CUSTOMIZED_SDK_URL="  . $ENV{'CUSTOMIZED_SDK_URL'};
 		}
-		if ($ENV{'CUSTOMIZED_SDK_URL_CREDENTIAL_ID'} ne '') {
+		if ( defined $ENV{'CUSTOMIZED_SDK_URL_CREDENTIAL_ID'} ) {
 			$jenkinsParam .= "&CUSTOMIZED_SDK_URL_CREDENTIAL_ID=" . $ENV{'CUSTOMIZED_SDK_URL_CREDENTIAL_ID'};
 		}
-		if ($ENV{'UPSTREAM_JOB_NAME'} ne '') {
+		if ( defined $ENV{'UPSTREAM_JOB_NAME'} ) {
 			$jenkinsParam .= "&UPSTREAM_JOB_NAME="   . $ENV{'UPSTREAM_JOB_NAME'};
 		}
-		if ($ENV{'UPSTREAM_JOB_NUMBER'} ne '') {
+		if ( defined $ENV{'UPSTREAM_JOB_NUMBER'} ) {
 			$jenkinsParam .= "&UPSTREAM_JOB_NUMBER=" . $ENV{'UPSTREAM_JOB_NUMBER'};
 		}
 


### PR DESCRIPTION
This change will make it easier to avoid resubmitting jobs with incorrect parameters when using the Grinder links at the bottom of the console log output. There are two changes here:
1. Previously on 32-bit ARM runs, the Grinder link would set `PLATFORM` to `aarch32_linux`. This is incorrect and this PR adjusts that to be `arm_linux`
2. Some of the parameters use by jenkins, will now be added to the Grinder parameters if they are located in the environment (as they will be for jobs run through jenkins). These will allow the acquisition of the correct source materials used for the testing to take place. The following environment variables are the ones that will now be captured in the grinder re-run logs in the bottom of the console log: `SDK_RESOURCE`, `CUSTOMIZED_SDK_URL`, `CUSTOMIZED_SDK_URL_CREDENTIAL_ID`, `UPSTREAM_JOB_NAME`, `UPSTREAM_JOB_NUMBER` and the TCK-specific `JCK_GIT_REPO`.

Signed-off-by: Stewart X Addison <sxa@redhat.com>