### PR TITLE
Replace grep -p with standard UNIX awk operation

### DIFF
--- a/scripts/getTestenvProperties.sh
+++ b/scripts/getTestenvProperties.sh
@@ -91,7 +91,8 @@ getTestenvProperties() {
 		fi
 
 		# append the info into $OUTPUT_FILE
-		{	echo "${REPO_NAME}_REPO=$(git remote show origin -n | grep -Po '(?<=Fetch URL: ).*')";
+		{
+			echo "${REPO_NAME}_REPO=$(git remote show origin -n | awk '/Fetch URL:/{print $3}')";
 			echo "${branch}=${REPO_SHA}";
 		}  2>&1 | tee -a $OUTPUT_FILE
 	else


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/3208

Running https://ci.adoptopenjdk.net/job/Grinder/2982/console to check

Looks like the same line that caused a problem before has passed without problems:
```
14:33:52  /home/jenkins/workspace/Grinder/aqa-tests/TKG/scripts/getTestenvProperties.sh --repo_dir /home/jenkins/workspace/Grinder/aqa-tests --output_file /home/jenkins/workspace/Grinder/aqa-tests/testenv/testenv.properties --repo_name ADOPTOPENJDK
14:33:52  Check sha in /home/jenkins/workspace/Grinder/aqa-tests and store the info in /home/jenkins/workspace/Grinder/aqa-tests/testenv/testenv.properties
14:33:52  ADOPTOPENJDK_REPO=https://github.com/AdoptOpenJDK/openjdk-tests.git
14:33:52  ADOPTOPENJDK_BRANCH=11c721b16a5906f9e5b35e36b49b1d130d231a01
```

Signed-off-by: Stewart X Addison <sxa@redhat.com>