### PR TITLE
Add sunos_x86-64, mode1000 to ottawa.csv

### DIFF
--- a/resources/ottawa.csv
+++ b/resources/ottawa.csv
@@ -178,4 +178,4 @@ variation:Mode110-OSRG,yes,yes,no,yes,yes,yes,no,yes,yes,yes,no,yes,no,yes,yes,y
 variation:Mode607-OSRG,no,no,yes,yes,no,no,yes,yes,no,no,yes,no,no,no,no,no,yes,yes,no,no,yes,yes,no,no,yes,yes,no,no,yes,yes,yes,yes,yes,no,yes,yes,no,no,no
 variation:Mode610-OSRG,no,no,yes,yes,no,no,yes,yes,no,no,yes,no,yes,yes,no,no,yes,yes,no,no,yes,yes,no,no,yes,yes,no,no,yes,yes,yes,yes,yes,no,yes,yes,no,no,no
 variation:Mode612-OSRG,no,no,yes,yes,no,no,yes,yes,no,no,yes,no,yes,yes,no,no,yes,yes,no,no,yes,yes,no,no,yes,yes,no,no,yes,yes,yes,yes,yes,no,yes,yes,no,no,no
-variation:Mode1000,yes,no,no,no,yes,no,no,no,yes,no,no,no,no,no,yes,no,no,no,yes,no,no,no,yes,no,no,no,yes,no,no,no,no,no,no,no,no,no,no,no,no
+variation:Mode1000,yes,no,no,no,yes,no,no,no,yes,no,no,no,no,no,yes,no,no,no,yes,no,no,no,yes,no,no,no,yes,no,no,no,no,no,yes,no,no,no,no,no,no


### PR DESCRIPTION
Add sunos_x86-64, mode1000 to ottawa.csv in order to enable the smoke tests

Fixes: #245 

Signed-off-by: Jerome Ju <jeromeqju@gmail.com>