### PR TITLE
Set VM_SUBDIR for cmprssptrs in openj9Settings.mk

### DIFF
--- a/openj9Settings.mk
+++ b/openj9Settings.mk
@@ -26,7 +26,7 @@ TEST_JDK_BIN:=$(TEST_JDK_HOME)$(D)bin
 TEST_JDK_LIB_DIR:=$(TEST_JDK_BIN)$(D)..$(D)lib
 
 VM_SUBDIR=default
-ifneq (,$(findstring cmprssptrs,$(SPEC)))
+ifneq (,$(findstring _cmprssptrs,$(SPEC)))
 VM_SUBDIR=compressedrefs
 endif
 


### PR DESCRIPTION
This commit changes the condition for setting VM_SUBDIR in
openj9Settings.mk.

The code without this change sets "compressedrefs" to VM_SUBDIR by
mistake for SPEC like "os_cpu_nocmprssptrs".

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>