### PR TITLE
Use a specific name for SCC

### DIFF
--- a/featureSettings.mk
+++ b/featureSettings.mk
@@ -16,7 +16,7 @@ ifneq (,$(findstring AOT,$(TEST_FLAG)))
 export TR_silentEnv=1
 export TR_Options=forceAOT
 export TR_OptionsAOT=forceAOT
-AOT_OPTIONS = -Xshareclasses:name=$@ -Xscmx400M -Xscmaxaot256m
+AOT_OPTIONS = -Xshareclasses:name=test_aot -Xscmx400M -Xscmaxaot256m
 ifndef TEST_ITERATIONS
 TEST_ITERATIONS = 2
 endif


### PR DESCRIPTION
There are some tests [1] that fail because the SCC name is too large.
The SCC name when the aot test flag is set is derived from the test
name. In order to prevent this issue, simply use the same name for all
tests. This is ok because prior to and after running tests, all SCCs are
destroyed. Additionally, this does not impact any future ability to run
tests in parallel as this is already not possible; the fact that all
SCCs are destroyed between tests means that one test could impact the
validity of another.

[1] https://github.com/eclipse-openj9/openj9/issues/14461

Fixes https://github.com/eclipse-openj9/openj9/issues/14461