### PR TITLE
feat: add java version into TAP file

### DIFF
--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -234,7 +234,7 @@ sub resultReporter {
 		open(my $fhOut, '>', $tapFile) or die "Cannot open file $tapFile!";
 		my $timeStamp = gmtime();
 		#generate java version, make oneline in format
-		my $javaVersion = `java -version 2>&1`;
+		my $javaVersion = `$ENV{'TEST_JDK_HOME'}/bin/java -version 2>&1`;
 		$javaVersion =~ s/\n/\n# /g;
 		print $fhOut "# " . $javaVersion . "\n";
 		print $fhOut "# Timestamp: " . $timeStamp . " UTC \n";

--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -233,7 +233,7 @@ sub resultReporter {
 		}
 		open(my $fhOut, '>', $tapFile) or die "Cannot open file $tapFile!";
 		my $timeStamp = gmtime();
-		print $fhOut "# java version: " . $ENV{'JDK_VERSION'} . "\n";
+		print $fhOut "# java version: " . $jdkVersion . "\n";
 		print $fhOut "# Timestamp: " . $timeStamp . " UTC \n";
 		print $fhOut "1.." . $numOfTotal . "\n";
 		print $fhOut $tapString;

--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -233,6 +233,7 @@ sub resultReporter {
 		}
 		open(my $fhOut, '>', $tapFile) or die "Cannot open file $tapFile!";
 		my $timeStamp = gmtime();
+		print $fhOut "# java version: " . $ENV{'JDK_VERSION'} . "\n";
 		print $fhOut "# Timestamp: " . $timeStamp . " UTC \n";
 		print $fhOut "1.." . $numOfTotal . "\n";
 		print $fhOut $tapString;

--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -233,7 +233,10 @@ sub resultReporter {
 		}
 		open(my $fhOut, '>', $tapFile) or die "Cannot open file $tapFile!";
 		my $timeStamp = gmtime();
-		print $fhOut "# java version: " . $jdkVersion . "\n";
+		#generate java version, make oneline in format
+		my $javaVersion = `java -version 2>&1`;
+		$javaVersion =~ tr/\n/\t/;
+		print $fhOut "# " . $javaVersion . "\n";
 		print $fhOut "# Timestamp: " . $timeStamp . " UTC \n";
 		print $fhOut "1.." . $numOfTotal . "\n";
 		print $fhOut $tapString;

--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -235,7 +235,7 @@ sub resultReporter {
 		my $timeStamp = gmtime();
 		#generate java version, make oneline in format
 		my $javaVersion = `java -version 2>&1`;
-		$javaVersion =~ tr/\n/\t/;
+		$javaVersion =~ s/\n/\n# /g;
 		print $fhOut "# " . $javaVersion . "\n";
 		print $fhOut "# Timestamp: " . $timeStamp . " UTC \n";
 		print $fhOut "1.." . $numOfTotal . "\n";


### PR DESCRIPTION
choose to run "java -version" instead of get info directly from AQACert.log is because flag AUTO_DETECT need to be enabled for the run. so it is safe to run command
Ref: https://github.com/adoptium/TKG/issues/312