### PR TITLE
Fix issue with TKG traverse

### DIFF
--- a/src/org/testKitGen/BuildList.java
+++ b/src/org/testKitGen/BuildList.java
@@ -44,12 +44,24 @@ public class BuildList {
 		}
 	}
 
-	public boolean contains(String dir) {
+	public boolean isRelated(String dir) {
 		if (originalSet.isEmpty()) {
 			return true;
 		}
 		for (String buildPath : originalSet) {
 			if (dir.equals(buildPath) || dir.equals("") || dir.contains(buildPath + "/") || buildPath.contains(dir + "/")) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public boolean contains(String dir) {
+		if (originalSet.isEmpty()) {
+			return true;
+		}
+		for (String buildPath : originalSet) {
+			if (dir.equals(buildPath) || dir.contains(buildPath + "/")) {
 				return true;
 			}
 		}

--- a/src/org/testKitGen/DirectoryWalker.java
+++ b/src/org/testKitGen/DirectoryWalker.java
@@ -38,7 +38,7 @@ public class DirectoryWalker {
 			absoluteDir = absoluteDir + '/' + currentDir;
 		}
 
-		if (!bl.contains(currentDir)) {
+		if (!bl.isRelated(currentDir)) {
 			return false;
 		}
 
@@ -49,7 +49,7 @@ public class DirectoryWalker {
 		List<String> subDirsWithTest = new ArrayList<String>();
 		for (File entry : dir) {
 			File file = new File(absoluteDir + '/' + entry.getName());
-			if (file.isFile() && entry.getName().equals(Constants.PLAYLIST)) {
+			if (bl.contains(currentDir) && file.isFile() && entry.getName().equals(Constants.PLAYLIST)) {
 				playlistXML = file;
 			} else if (file.isDirectory()) {
 				dirList.add(entry.getName());


### PR DESCRIPTION
- stop consuming playlist in parent folder when buildlist only contains its subfolder

Signed-off-by: renfeiw <renfeiw@ca.ibm.com>