### PR TITLE
add platform map for win_aarch64

### DIFF
--- a/resources/buildPlatformMap.properties
+++ b/resources/buildPlatformMap.properties
@@ -50,6 +50,7 @@ sunos_x86-64=x86-64_solaris
 win_x86-64_nocmprssptrs=x86-64_windows_xl
 win_x86-64_cmprssptrs=x86-64_windows_cmprssptrs
 win_x86-64=x86-64_windows
+win_aarch64=aarch64_windows
 win_x86=x86-32_windows
 zos_390-64_nocmprssptrs=s390x_zos_xl
 zos_390-64_cmprssptrs=s390x_zos_cmprssptrs


### PR DESCRIPTION
Fixes the failing Windows aarch64 smoke tests