### PR TITLE
Use a specific version of jcstress jar to bypass sha file look up which causes issues on z/OS

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -168,8 +168,7 @@ my %base = (
 		url => 'https://builds.shipilev.net/jcstress/jcstress-latest.jar',
 		fname => 'jcstress-latest.jar',
 		shaurl => 'https://builds.shipilev.net/jcstress/SHA1SUMS',
-		shafn => 'SHA1SUMS',
-		sha1 => '703854d4e6416076eab1648455d95176ebd49baf'
+		shafn => 'SHA1SUMS'
 	});
 
 my @dependencies = split(',', $dependencyList);

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -165,10 +165,9 @@ my %base = (
 	}, 
 	
 	jcstress => {
-		url => 'https://builds.shipilev.net/jcstress/jcstress-latest.jar',
-		fname => 'jcstress-latest.jar',
-		shaurl => 'https://builds.shipilev.net/jcstress/SHA1SUMS',
-		shafn => 'SHA1SUMS'
+		url => 'https://builds.shipilev.net/jcstress/jcstress-tests-all-20220908.jar',
+		fname => 'jcstress-tests-all-20220908.jar',
+		sha1 => '8cf348be49b8af939a3ce03216e3df53aa0f9ef2'
 	});
 
 my @dependencies = split(',', $dependencyList);


### PR DESCRIPTION
As a temporary work around to bypass the z/OS issue related to jcstress jar SHA checking (openj9-openjdk-jdk11-zos/issues/1623), use a specific version of jcstress jar. 

Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>