### PR TITLE
Adding Linux_ppc-64 support

### DIFF
--- a/resources/buildPlatformMap.properties
+++ b/resources/buildPlatformMap.properties
@@ -30,6 +30,7 @@ linux_ppc-64_nocmprssptrs=ppc64_linux_xl
 linux_ppc-64_cmprssptrs=ppc64_linux_cmprssptrs
 linux_ppc-64_cmprssptrs_le=ppc64le_linux_cmprssptrs
 linux_ppc-64_nocmprssptrs_le=ppc64le_linux_xl
+linux_ppc-64=ppc64_linux
 linux_ppc-64_le=ppc64le_linux
 linux_ppc=ppc32_linux
 linux_riscv64_nocmprssptrs=riscv64_linux_xl


### PR DESCRIPTION
Adding support for Linux_ppc-64

Error: Please update file resources/buildPlatformMap.properties! Add entry for linux_ppc-64.
11:53:26  makeGen.mk:45: recipe for target 'autogen' failed

Link: Test_grinder/job/Grinder_CR/974