### PR TITLE
Update getDependencies.pl

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -143,13 +143,6 @@ my %base = (
 		shafn => 'jtreg_6_1_1.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
-	jtreg_7_1 => {
-		url => 'https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7+1.tar.gz',
-		fname => 'jtreg_7_1.tar.gz',
-		shaurl => 'https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7+1.tar.gz.sha256sum.txt',
-		shafn => 'jtreg_7_1.tar.gz.sha256sum.txt',
-		shaalg => '256'
-	},
 	jtreg_7_1_1_1 => {
 		url => 'https://ci.adoptopenjdk.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.1.1+1.tar.gz',
 		fname => 'jtreg_7_1_1_1.tar.gz',


### PR DESCRIPTION
Update jtreg in openjdk test

This patch removes older jtreg version 7.1.

Fixes: [#4198](https://github.com/adoptium/aqa-tests/issues/4198#issuecomment-1412688529)

Signed-off-by: Full Name <email>