### PR TITLE
Support defining a range of jdk versions

### DIFF
--- a/examples/jdkVersion/playlist.xml
+++ b/examples/jdkVersion/playlist.xml
@@ -1,0 +1,92 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+	<test>
+		<testCaseName>test_ver_11</testCaseName>
+		<command>echo "test for version 11"; \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>11</version>
+		</versions>
+	</test>
+
+	<test>
+		<testCaseName>test_ver_17plus</testCaseName>
+		<command>echo "test for version 17+"; \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>17+</version>
+		</versions>
+	</test>
+
+	<test>
+		<testCaseName>test_ver_8to11</testCaseName>
+		<command>echo "test for version 8 to 11"; \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>[8, 11]</version>
+		</versions>
+	</test>
+
+	<test>
+		<testCaseName>test_ver_8to11and17plus</testCaseName>
+		<command>echo "test for version 8 to 11 and 17+"; \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>[8, 11]</version>
+			<version>17+</version>
+		</versions>
+	</test>
+
+	<test>
+		<testCaseName>test_disable_ver_11</testCaseName>
+		<disables>
+			<disable>
+				<comment>disable version 11</comment>
+				<version>11</version>
+			</disable>
+		</disables>
+		<command>echo "disable test for version 11"; \
+	$(TEST_STATUS)</command>
+	</test>
+
+	<test>
+		<testCaseName>test_disable_ver_11to17</testCaseName>
+		<disables>
+			<disable>
+				<comment>disable version 11 to 17</comment>
+				<version>[11, 17]</version>
+			</disable>
+		</disables>
+		<command>echo "disable test for version 11 to 17"; \
+	$(TEST_STATUS)</command>
+	</test>
+
+	<test>
+		<testCaseName>test_disable_ver_8and17plus</testCaseName>
+		<disables>
+			<disable>
+				<comment>disable version 8</comment>
+				<version>8</version>
+			</disable>
+			<disable>
+				<comment>disable version 11</comment>
+				<version>17+</version>
+			</disable>
+		</disables>
+		<command>echo "disable test for version 8 and 17+"; \
+	$(TEST_STATUS)</command>
+	</test>
+</playlist>

--- a/src/org/testKitGen/TestInfoParser.java
+++ b/src/org/testKitGen/TestInfoParser.java
@@ -193,23 +193,36 @@ public class TestInfoParser {
 	}
 
 	private boolean checkJavaVersion(String version) {
-		boolean rt = false;
 		if (version.equalsIgnoreCase(arg.getJdkVersion())) {
-			rt = true;
+			return true;
 		} else {
 			try {
-				Pattern pattern = Pattern.compile("^(.*)\\+$");
+				Pattern pattern = Pattern.compile("^\\[(.*),(.*)\\]$");
 				Matcher matcher = pattern.matcher(version);
 				if (matcher.matches()) {
+					String start = matcher.group(1).trim();
+					String end = matcher.group(2).trim();
+					int currentVersion = Integer.parseInt(arg.getJdkVersion());
+					System.out.println(Integer.parseInt(start) + " " + Integer.parseInt(end) + " .  " + currentVersion);
+
+					if (currentVersion >= Integer.parseInt(start)
+						&& currentVersion <= Integer.parseInt(end)) {
+						return true;
+					}
+				}
+
+				pattern = Pattern.compile("^(.*)\\+$");
+				matcher = pattern.matcher(version);
+				if (matcher.matches()) {
 					if (Integer.parseInt(matcher.group(1)) <= Integer.parseInt(arg.getJdkVersion())) {
-						rt = true;
+						return true;
 					}
 				}
 			} catch (NumberFormatException e) {
-				// Nothing to do
+				System.out.println("Warning: jdk version is not an integer, couldn't parse it.");
 			}
 		}
-		return rt;
+		return false;
 	}
 
 	private void parseDisableInfo(TestInfo ti) {


### PR DESCRIPTION
- update parser logic
- add testcase/example for jdk version
- add testcase/example for disable jdk version
- add verbose option for tkg test

Fixes: #390

Signed-off-by: renfeiw <renfeiw@ca.ibm.com>