### PR TITLE
support test failed as error and test naming ending with #id* in tap file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ buildInfo.mk
 SHA.txt
 
 .DS_Store
+
+/.project

--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -161,7 +161,7 @@ sub resultReporter {
 								my $failureTests = "";
 								for my $i (0 .. $#lines) {
 									if ( $lines[$i] =~ /[-]{50}/) {
-										if ( ($lines[$i+1] =~ /(TEST: )(.*?)(\.java|\.sh)$/) || ($lines[$i+1] =~ /(Test results: )(.*failed: )(\d{1,}$)/) ) {
+										if ( ($lines[$i+1] =~ /(TEST: )(.*?)(\.java|\.sh)$/) || ($lines[$i+1] =~ /(Test results: .*)(failed|error)(: \d{1,}$)/) ) {
 											$i++;
 											$failureTests .= $lines[$i] . "\n";
 										}

--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -161,7 +161,7 @@ sub resultReporter {
 								my $failureTests = "";
 								for my $i (0 .. $#lines) {
 									if ( $lines[$i] =~ /[-]{50}/) {
-										if ( ($lines[$i+1] =~ /(TEST: )(.*?)(\.java|\.sh)$/) || ($lines[$i+1] =~ /(Test results: .*)(failed|error)(: \d{1,}$)/) ) {
+										if ( ($lines[$i+1] =~ /(TEST: )(.*?)(\.java|\.sh|#id\d{1,})$/) || ($lines[$i+1] =~ /(Test results: .*)(failed|error)(: \d{1,}$)/) ) {
 											$i++;
 											$failureTests .= $lines[$i] . "\n";
 										}


### PR DESCRIPTION
Support test result as error
Test results: passed: 105; failed: 7; error: 1

test naming ending with #id*
TEST: java/lang/Thread/virtual/stress/PinALot.java#id0

Fix #407 
Fix #408 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>