### PR TITLE
add the ability to pass EXTRA_DOCKER_ARGS via the command line

### DIFF
--- a/settings.mk
+++ b/settings.mk
@@ -380,7 +380,7 @@ setup_%: testEnvSetup
 	@$(ECHO) set JAVA_HOME to $(JAVA_HOME)
 	@$(ECHO) set SPEC to $(SPEC)
 	@$(ECHO) set TEST_FLAG to $(TEST_FLAG)
-	@$(ECHO) set DOCKER_ARGS to $(DOCKER_ARGS)
+	@$(ECHO) set EXTRA_DOCKER_ARGS to $(EXTRA_DOCKER_ARGS)
 
 	@$(MKTREE) $(Q)$(TESTOUTPUT)$(Q)
 	@$(ECHO) Running $(TESTTARGET) ...

--- a/settings.mk
+++ b/settings.mk
@@ -380,6 +380,7 @@ setup_%: testEnvSetup
 	@$(ECHO) set JAVA_HOME to $(JAVA_HOME)
 	@$(ECHO) set SPEC to $(SPEC)
 	@$(ECHO) set TEST_FLAG to $(TEST_FLAG)
+	@$(ECHO) set DOCKER_ARGS to $(DOCKER_ARGS)
 
 	@$(MKTREE) $(Q)$(TESTOUTPUT)$(Q)
 	@$(ECHO) Running $(TESTTARGET) ...

--- a/src/org/testKitGen/MkGen.java
+++ b/src/org/testKitGen/MkGen.java
@@ -93,9 +93,9 @@ public class MkGen {
 				f.write(testTargetName + ": JVM_OPTIONS?=" + testInfo.getAotOptions() + "$(RESERVED_OPTIONS) "
 						+ (var.getJvmOptions().isEmpty() ? "" : (var.getJvmOptions() + " ")) + "$(EXTRA_OPTIONS)\n");
 
-				// Add DOCKER_ARGS if it is not empty
+				// Add EXTRA_DOCKER_ARGS if it is not empty
 				if (!var.getDockerArgs().isEmpty()) {
-					f.write(testTargetName + ": DOCKER_ARGS=" + var.getDockerArgs() + "\n");
+					f.write(testTargetName + ": EXTRA_DOCKER_ARGS=" + var.getDockerArgs() + "\n");
 				}
 
 				f.write(testTargetName + ": TEST_GROUP=" + testInfo.getLevelStr() + "\n");

--- a/src/org/testKitGen/MkGen.java
+++ b/src/org/testKitGen/MkGen.java
@@ -93,6 +93,11 @@ public class MkGen {
 				f.write(testTargetName + ": JVM_OPTIONS?=" + testInfo.getAotOptions() + "$(RESERVED_OPTIONS) "
 						+ (var.getJvmOptions().isEmpty() ? "" : (var.getJvmOptions() + " ")) + "$(EXTRA_OPTIONS)\n");
 
+				// Add DOCKER_ARGS if it is not empty
+				if (!var.getDockerArgs().isEmpty()) {
+					f.write(testTargetName + ": DOCKER_ARGS=" + var.getDockerArgs() + "\n");
+				}
+
 				f.write(testTargetName + ": TEST_GROUP=" + testInfo.getLevelStr() + "\n");
 				f.write(testTargetName + ": TEST_ITERATIONS=" + testInfo.getIterations() + "\n");
 				f.write(testTargetName + ": AOT_ITERATIONS=" + testInfo.getAotIterations() + "\n");

--- a/src/org/testKitGen/Variation.java
+++ b/src/org/testKitGen/Variation.java
@@ -25,6 +25,7 @@ public class Variation {
 	private String subTestName;
 	private String mode;
 	private String jvmOptions;
+	private String dockerArgs;
 	private boolean isValid;
 	private List<String> disabledReasons;
 	private PrintStatus status;
@@ -35,6 +36,7 @@ public class Variation {
 		this.variation = variation;
 		this.isValid = true;
 		this.jvmOptions = "";
+		this.dockerArgs = "";
 		this.disabledReasons = new ArrayList<String>();
 		this.status = PrintStatus.DO_NOT_PRINT;
 		this.prefix = "";
@@ -58,6 +60,10 @@ public class Variation {
 
 	public String getJvmOptions() {
 		return this.jvmOptions;
+	}
+
+	public String getDockerArgs() {
+		return this.dockerArgs;
 	}
 
 	public void setJvmOptions(String jvmOptions) {


### PR DESCRIPTION
This PR allows me to pass `DOCKER_ARGS` as a command line value:

e.g:

```bash
make _testList TESTLIST=tfb-spring-verify EXTRA_DOCKER_ARGS ="--cpus=1.0 --memory=8g"
```

to then be used in a playlist.xml file:

```xml
	<test>
		<testCaseName>tfb-spring-verify</testCaseName>
		<command>export DOCKER_ARGS=$(Q)$(EXTRA_DOCKER_ARGS)$(Q); bash $(Q)$(TEST_RESROOT)$(D)FrameworkBenchmarks/tfb$(Q) --mode verify --test spring; \
		$(TEST_STATUS)</command>
		<levels>
			<level>sanity</level>
		</levels>
		<groups>
			<group>perf</group>
		</groups>
	</test>
```
