### PR TITLE
Move getJtreg into getDependencies

### DIFF
--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -22,6 +22,80 @@
 
 	<!-- set default LIB property to all -->
 	<property name="LIB" value="all" />
+	<target name="getJtregVersion">
+		<if>
+			<!-- versions 8-10, 12-16 -->
+			<matches pattern="^([89]|1[02-6])$" string="${JDK_VERSION}"/>
+			<then>
+				<property name="jtregTar" value="jtreg_5_1_b01"/>
+			</then>
+			<elseif>
+				<!-- version 11 -->
+				<matches pattern="^11$" string="${JDK_VERSION}"/>
+				<then>
+					<property name="jtregTar" value="jtreg_6_1"/>
+				</then>
+			</elseif>
+			<elseif>
+				<!-- versions 17, 21, 22 -->
+				<matches pattern="^(17|2[12])$" string="${JDK_VERSION}"/>
+				<then>
+					<property name="jtregTar" value="jtreg_7_3_1_1"/>
+				</then>
+			</elseif>
+			<else>
+				<fail message="Unsupported JDK version: ${JDK_VERSION}"/>
+			</else>
+		</if>
+
+		<if>
+			<or>
+				<equals arg1="${JDK_IMPL}" arg2="ibm"/>
+				<equals arg1="${JDK_IMPL}" arg2="openj9"/>
+			</or>
+			<then>
+				<property name="openj9jtregtimeouthandler" value=",tohandler_simple"/>
+			</then>
+			<else>
+				<property name="openj9jtregtimeouthandler" value=""/>
+			</else>
+		</if>
+		<var name="LIB" unset="true"/>
+		<property name="LIB" value="${jtregTar}${openj9jtregtimeouthandler}"/>
+	</target>
+	
+	<target name="getJtreg" depends="getJtregVersion,getDependentLibs">
+		<mkdir dir="${DEST}"/>
+		<if>
+			<available file="${LIB_DIR}/${jtregTar}.tar.gz"/>
+			<then>
+				<copy file="${LIB_DIR}/${jtregTar}.tar.gz" tofile="${jtregTar}.tar.gz"/>
+			</then>
+			<elseif>
+				<available file="custom_jtreg.tar.gz"/>
+				<then>
+					<echo message="Using custom_jtreg.tar.gz"/>
+					<copy file="custom_jtreg.tar.gz" tofile="${jtregTar}.tar.gz"/>
+				</then>
+			</elseif>
+		</if>
+		<exec executable="gzip" failonerror="true">
+			<arg line="-df ${jtregTar}.tar.gz"/>
+		</exec>
+		<if>
+			<contains string="${SPEC}" substring="zos"/>
+			<then>
+				<exec executable="tar" failonerror="true">
+					<arg line="xfo ${jtregTar}.tar -C ${DEST}"/>
+				</exec>
+			</then>
+			<else>
+				<exec executable="sh" failonerror="true">
+					<arg line="-c 'cat ${jtregTar}.tar | (cd ${DEST} &amp;&amp; tar xof -)'"/>
+				</exec>
+			</else>
+		</if>
+	</target>
 
 	<target name="getDependentLibs" unless="skipDependency">
 		<exec executable="perl" failonerror="true">


### PR DESCRIPTION
-Moved the getJtreg version download logic into TKG/scripts/getDependencies.xml

resolves : https://github.com/adoptium/aqa-tests/issues/4848