### PR TITLE
Allow LIB_DIR, customUrl and curlOpts to be set for get dependency logic

### DIFF
--- a/makefile
+++ b/makefile
@@ -88,7 +88,7 @@ endif
 # compile tools
 #######################################
 include moveDmp.mk
-COMPILE_TOOLS_CMD=ant -f .$(D)scripts$(D)build_tools.xml -DTEST_JDK_HOME=$(TEST_JDK_HOME) -DTEST_ROOT=$(TEST_ROOT)
+COMPILE_TOOLS_CMD=ant -f .$(D)scripts$(D)build_tools.xml -DTEST_JDK_HOME=$(TEST_JDK_HOME) -DTEST_ROOT=$(TEST_ROOT) -DLIB_DIR=$(LIB_DIR)
 
 compileTools:
 	$(RM) -r $(COMPILATION_OUTPUT); \

--- a/scripts/build_tools.xml
+++ b/scripts/build_tools.xml
@@ -21,7 +21,7 @@
 
 	<property name="src" location="../src" />
 	<property name="build" location="../bin" />
-	<property name="json.jar" location="../lib/json-simple.jar" />
+	<property name="json.jar" location="${LIB_DIR}/json-simple.jar" />
 	<property name="LIB" value="json_simple"/>
 	<import file="./getDependencies.xml"/>
 

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -27,10 +27,14 @@ my $path;
 # define task
 my $task = "default";
 my $dependencyList = "all";
+my $customUrl = "";
+my $curlOpts = "";
 
 GetOptions ("path=s" => \$path,
 			"task=s" => \$task,
-			"dependencyList=s" => \$dependencyList)
+			"dependencyList=s" => \$dependencyList,
+			"customUrl=s" => \$customUrl,
+			"curlOpts=s" => \$curlOpts)
 	or die("Error in command line arguments\n");
 
 if (not defined $path) {
@@ -188,6 +192,15 @@ if ($task eq "clean") {
 		my $filename = $path . $sep . $fn;
 		my $shaurl = $jars_info[$i]{shaurl};
 		my $shafn = $jars_info[$i]{shafn};
+
+		# if customUrl is provided, use customUrl and reset $url and $shaurl
+		if ($customUrl ne "") {
+			$url = "$customUrl/$fn";
+			if (defined $shaurl && $shaurl ne '') {
+				$shaurl = "$customUrl/$shafn";
+			}
+		}
+
 		my $shaalg = $jars_info[$i]{shaalg};
 		if (!$shaalg) {
 			$shaalg = "sha1";
@@ -279,9 +292,9 @@ sub downloadFile {
 	# .txt SHA files are in ISO8859-1
 	# note _ENCODE_FILE_NEW flag is set for zos
 	if ('.txt' eq substr $filename, -length('.txt')) {
-		$output = qx{_ENCODE_FILE_NEW=ISO8859-1 curl -k -o $filename $url 2>&1};
+		$output = qx{_ENCODE_FILE_NEW=ISO8859-1 curl $curlOpts -k -o $filename $url 2>&1};
 	} else {
-		$output = qx{_ENCODE_FILE_NEW=UNTAGGED curl -k -o $filename $url 2>&1};
+		$output = qx{_ENCODE_FILE_NEW=UNTAGGED curl $curlOpts -k -o $filename $url 2>&1};
 	}
 	my $returnCode = $?;
 	if ($returnCode == 0) {

--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -99,7 +99,7 @@
 
 	<target name="getDependentLibs" unless="skipDependency">
 		<exec executable="perl" failonerror="true">
-			<arg line="${TEST_ROOT}/TKG/scripts/getDependencies.pl -path ${TEST_ROOT}/TKG/lib -task default -dependencyList ${LIB}"/>
+			<arg line="${TEST_ROOT}/TKG/scripts/getDependencies.pl -path ${LIB_DIR} -task default -dependencyList ${LIB}"/>
 		</exec>
 	</target>
 </project>

--- a/settings.mk
+++ b/settings.mk
@@ -171,7 +171,14 @@ endif
 #######################################
 # common dir and jars
 #######################################
-LIB_DIR=$(TEST_ROOT)$(D)TKG$(D)lib
+ifndef LIB_DIR
+	LIB_DIR:=$(TEST_ROOT)$(D)TKG$(D)lib
+endif
+ifeq ($(CYGWIN),1)
+	LIB_DIR:=$(shell cygpath -w $(LIB_DIR))
+endif
+LIB_DIR:=$(subst \,/,$(LIB_DIR))
+
 TESTNG=$(LIB_DIR)$(D)testng.jar$(P)$(LIB_DIR)$(D)jcommander.jar
 RESOURCES_DIR=$(JVM_TEST_ROOT)$(D)TestConfig$(D)resources
 


### PR DESCRIPTION
need to merge with https://github.com/adoptium/aqa-tests/pull/4902

related: https://github.com/adoptium/aqa-tests/issues/4500