### PR TITLE
Add a new feature CRAC

### DIFF
--- a/src/org/openj9/envInfo/JavaInfo.java
+++ b/src/org/openj9/envInfo/JavaInfo.java
@@ -229,6 +229,7 @@ public class JavaInfo {
         String isCRIUCapable = System.getProperty("org.eclipse.openj9.criu.isCRIUCapable");
         if ((isCRIUCapable != null) && isCRIUCapable.equals("true")) {
             detectedTfs.add("CRIU");
+            detectedTfs.add("CRAC");
         }
     }
 


### PR DESCRIPTION
Add a new feature `CRAC`

Currently, `CRAC` is set as `CRIU` when the system property `org.eclipse.openj9.criu.isCRIUCapable` is true.

Related to https://github.com/eclipse-openj9/openj9/pull/18627#discussion_r1442371415

Signed-off-by: Jason Feng <fengj@ca.ibm.com>