### PR TITLE
CRaC is only supported on Linux amd64

### DIFF
--- a/src/org/openj9/envInfo/JavaInfo.java
+++ b/src/org/openj9/envInfo/JavaInfo.java
@@ -226,10 +226,13 @@ public class JavaInfo {
     }
 
     public void checkCRIU() {
-        String isCRIUCapable = System.getProperty("org.eclipse.openj9.criu.isCRIUCapable");
-        if ((isCRIUCapable != null) && isCRIUCapable.equals("true")) {
+        if ("true".equalsIgnoreCase(System.getProperty("org.eclipse.openj9.criu.isCRIUCapable"))) {
+            // CRIU is only supported on Linux.
             detectedTfs.add("CRIU");
-            detectedTfs.add("CRAC");
+            if ("amd64".equalsIgnoreCase(System.getProperty("os.arch"))) {
+                // CRaC is only supported on Linux amd64.
+                detectedTfs.add("CRAC");
+            }
         }
     }
 


### PR DESCRIPTION
`CRaC` is only supported on `Linux amd64`

Verified in [a grinder](https://hyc-runtimes-jenkins.swg-devops.com/job/Test_openjdk11_j9_sanity.functional_s390x_linux_testList_0/605/consoleFull)
`-DTEST_FLAG=CRIU` for non-xa64 platform.

This should fix the test compilation error - https://openj9-jenkins.osuosl.org/job/Test_openjdk11_j9_sanity.functional_s390x_linux_ojdk292_Personal_testList_0/6/consoleFull
```
11:33:14      [javac] /home/jenkins/workspace/Test_openjdk11_j9_sanity.functional_s390x_linux_ojdk292_Personal_testList_0/aqa-tests/functional/cmdLineTests/criu/src/org/openj9/criu/TestJDKCRAC.java:31: error: cannot find symbol
11:33:14      [javac] 		Path imagePath = Paths.get(InternalCRIUSupport.getCRaCCheckpointToDir());
11:33:14      [javac] 		                                              ^
11:33:14      [javac]   symbol:   method getCRaCCheckpointToDir()
11:33:14      [javac]   location: class InternalCRIUSupport
11:33:14      [javac] /home/jenkins/workspace/Test_openjdk11_j9_sanity.functional_s390x_linux_ojdk292_Personal_testList_0/aqa-tests/functional/cmdLineTests/criu/src/org/openj9/criu/TestJDKCRAC.java:36: error: package jdk.crac does not exist
11:33:14      [javac] 		jdk.crac.Core.checkpointRestore();
11:33:14      [javac] 		        ^
11:33:14      [javac] 2 errors
```

closes https://github.com/eclipse-openj9/openj9/issues/18822

Signed-off-by: Jason Feng <fengj@ca.ibm.com>