### PR TITLE
Fix schema location in playlist.xml files

### DIFF
--- a/examples/base/playlist.xml
+++ b/examples/base/playlist.xml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../resources/playlist.xsd">
 	<test>
 		<testCaseName>testSuccess</testCaseName>
 		<command>echo "success"; \

--- a/examples/feature/playlist.xml
+++ b/examples/feature/playlist.xml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../resources/playlist.xsd">
 	<test>
 		<testCaseName>testFeatureFips</testCaseName>
 		<command>echo "match FIPS140_3_20220501 and everything else by default"; \

--- a/examples/hierarchy/a1/b1/playlist.xml
+++ b/examples/hierarchy/a1/b1/playlist.xml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../resources/playlist.xsd">
 	<test>
 		<testCaseName>test_a1_b1</testCaseName>
 		<command>echo "success"; \

--- a/examples/hierarchy/a2/b2/c2/playlist.xml
+++ b/examples/hierarchy/a2/b2/c2/playlist.xml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../resources/playlist.xsd">
 	<test>
 		<testCaseName>test_a2_b2_c2</testCaseName>
 		<command>echo "success"; \

--- a/examples/hierarchy/a2/b2/playlist.xml
+++ b/examples/hierarchy/a2/b2/playlist.xml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../resources/playlist.xsd">
 	<test>
 		<testCaseName>test_a2_b2</testCaseName>
 		<command>echo "success"; \

--- a/examples/hierarchy/a2/d2/playlist.xml
+++ b/examples/hierarchy/a2/d2/playlist.xml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../resources/playlist.xsd">
 	<test>
 		<testCaseName>test_a2_d2</testCaseName>
 		<command>echo "success"; \

--- a/examples/hierarchy/a2/playlist.xml
+++ b/examples/hierarchy/a2/playlist.xml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../resources/playlist.xsd">
 	<test>
 		<testCaseName>test_a2</testCaseName>
 		<command>echo "success"; \

--- a/examples/hierarchy/a3/b3/playlist.xml
+++ b/examples/hierarchy/a3/b3/playlist.xml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../resources/playlist.xsd">
 	<test>
 		<testCaseName>test_a3_b3</testCaseName>
 		<command>echo "success"; \

--- a/examples/hierarchy/a3/c3/d3/playlist.xml
+++ b/examples/hierarchy/a3/c3/d3/playlist.xml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../resources/playlist.xsd">
 	<test>
 		<testCaseName>test_a3_b3_c3_d3</testCaseName>
 		<command>echo "success"; \

--- a/examples/hierarchy/a3/f3/playlist.xml
+++ b/examples/hierarchy/a3/f3/playlist.xml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../resources/playlist.xsd">
 	<test>
 		<testCaseName>test_a3_f3</testCaseName>
 		<command>echo "success"; \

--- a/examples/jdkVersion/playlist.xml
+++ b/examples/jdkVersion/playlist.xml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../resources/playlist.xsd">
 	<test>
 		<testCaseName>test_ver_11</testCaseName>
 		<command>echo "test for version 11"; \

--- a/examples/platformRequirements/playlist.xml
+++ b/examples/platformRequirements/playlist.xml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../resources/playlist.xsd">
 	<test>
 		<testCaseName>test_arch_x86</testCaseName>
 		<command>echo "test arch.x86"; \

--- a/examples/rerun/playlist.xml
+++ b/examples/rerun/playlist.xml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../resources/playlist.xsd">
 	<test>
 		<testCaseName>testRerun</testCaseName>
 		<command>echo "test rerun"; \

--- a/examples/rerun/rerunSub/playlist.xml
+++ b/examples/rerun/rerunSub/playlist.xml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../resources/playlist.xsd">
 	<test>
 		<testCaseName>testRerunSubDir</testCaseName>
 		<command>echo "test rerun in sub dir"; \

--- a/examples/sliceAndDice/level/playlist.xml
+++ b/examples/sliceAndDice/level/playlist.xml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -->
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../resources/playlist.xsd">
 	<test>
 		<testCaseName>testDefault</testCaseName>
 		<command>echo "default is extended"; \


### PR DESCRIPTION
Location of xsd schema in example playlist.xml files is wrong. It probably currently does not matter, but should be fixed anyway.