### PR TITLE
Add CRAC when org.eclipse.openj9.criu.isCRaCCapable is set

### DIFF
--- a/src/org/openj9/envInfo/JavaInfo.java
+++ b/src/org/openj9/envInfo/JavaInfo.java
@@ -227,11 +227,10 @@ public class JavaInfo {
 
     public void checkCRIU() {
         if ("true".equalsIgnoreCase(System.getProperty("org.eclipse.openj9.criu.isCRIUCapable"))) {
-            // CRIU is only supported on Linux.
             detectedTfs.add("CRIU");
-            if ("amd64".equalsIgnoreCase(System.getProperty("os.arch"))) {
-                // CRaC is only supported on Linux amd64.
-                detectedTfs.add("CRAC");
+            // CRIU support is required by CRaC
+            if ("true".equalsIgnoreCase(System.getProperty("org.eclipse.openj9.criu.isCRaCCapable"))) {
+            	detectedTfs.add("CRAC");
             }
         }
     }


### PR DESCRIPTION
Add `CRAC` when `org.eclipse.openj9.criu.isCRaCCapable` is set

`CRIU` support is required by `CRaC`.

Depended on
* https://github.com/eclipse-openj9/openj9/pull/18928

FYI @tajila 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>