### PR TITLE
Limit overall test cases summary for all targets to openjdk and jck only

### DIFF
--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -317,7 +317,7 @@ sub resultReporter {
 	print "$testTargetStatus\n";
 	
 	print "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n\n";
-	if (@testCasesResults) { 
+	if (@testCasesResults && ($buildList =~ /openjdk/ || $buildList =~ /jck/)) { 
 		$testCasesAllTargetsSummary = getTestcaseResults(\@testCasesResults);
 		print $testCasesAllTargetsSummary . "\n";
 		print "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n";


### PR DESCRIPTION
Some of other category tests might also run with jtreg. In that case testcase summary per target is still useful.

Related #510