### PR TITLE
Disable Mode158 on AArch64 Linux

### DIFF
--- a/resources/ottawa.csv
+++ b/resources/ottawa.csv
@@ -62,7 +62,7 @@ variation:Mode154,no,no,yes,yes,no,no,yes,yes,no,no,yes,yes,no,yes,yes,no,no,no,
 variation:Mode155,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,yes,yes,yes,yes,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,yes,yes,no,no,no,no,no,yes,yes
 variation:Mode156,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,yes,yes
 variation:Mode157,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,yes,yes,yes,yes,no,no,no,no,no,no,no,yes,yes,yes,yes,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,yes,yes
-variation:Mode158,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,yes,yes,yes,yes,no,no,no,no,no,no,no,yes,yes,yes,yes,no,no,no,no,no,no,no,no,no,yes,yes,no,no,no,no,no,yes,yes
+variation:Mode158,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,yes,yes,yes,yes,no,no,no,no,no,no,no,yes,yes,yes,yes,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,yes,yes
 variation:Mode159,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,yes,yes,yes,yes,no,no,no,no,no,no,no,no,no,yes,yes,yes,yes,yes,no,no,yes,yes
 variation:Mode159-CS,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,yes,yes,yes,yes,no,no,no,no,no,no,no,no,no,no,no,yes,yes,yes,no,no,yes,yes
 variation:Mode166,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,yes,yes,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,yes,yes


### PR DESCRIPTION
This commit disables Mode158 on AArch64 Linux.
Mode158 is described as "test 3bit shifting(z/OS only)".