### PR TITLE
Add -Dfile.encoding=IBM-1047 for JDK21 zOS

### DIFF
--- a/makefile
+++ b/makefile
@@ -38,9 +38,18 @@ endif
 
 UNAME := uname
 UNAME_OS := $(shell $(UNAME) -s | cut -f1 -d_)
+$(info UNAME_OS is $(UNAME_OS))
 ifeq ($(findstring CYGWIN,$(UNAME_OS)), CYGWIN)
 	LIB_DIR:=$(shell cygpath -w $(LIB_DIR))
+else ifeq ($(UNAME_OS),OS/390)
+# The issue is still being investigated. See backlog/issues/1424
+# set -Dfile.encoding=IBM-1047 for JDK21+ zOS for now
+ifeq ($(shell test $(JDK_VERSION) -ge 21; echo $$?),0)
+export IBM_JAVA_OPTIONS="-Dfile.encoding=IBM-1047"
+$(info export IBM_JAVA_OPTIONS="-Dfile.encoding=IBM-1047")
 endif
+endif
+
 export LIB_DIR:=$(subst \,/,$(LIB_DIR))
 $(info LIB_DIR is set to $(LIB_DIR))
 


### PR DESCRIPTION
related: https://github.ibm.com/runtimes/backlog/issues/1424