### PR TITLE
Use jtreg 7.3.1+1 for JDK11 tests

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -160,13 +160,6 @@ my %base = (
 		shafn => 'jtreg_5_1_b01.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
-	jtreg_6_1 => {
-		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-6+1.tar.gz',
-		fname => 'jtreg_6_1.tar.gz',
-		shaurl => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-6+1.tar.gz.sha256sum.txt',
-		shafn => 'jtreg_6_1.tar.gz.sha256sum.txt',
-		shaalg => '256'
-	},
 	jtreg_7_3_1_1 => {
 		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.3.1+1.tar.gz',
 		fname => 'jtreg_7_3_1_1.tar.gz',

--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -29,22 +29,8 @@
 			<then>
 				<property name="jtregTar" value="jtreg_5_1_b01"/>
 			</then>
-			<elseif>
-				<!-- version 11 -->
-				<matches pattern="^11$" string="${JDK_VERSION}"/>
-				<then>
-					<property name="jtregTar" value="jtreg_6_1"/>
-				</then>
-			</elseif>
-			<elseif>
-				<!-- versions 17, 21, 22, 23 -->
-				<matches pattern="^(17|2[123])$" string="${JDK_VERSION}"/>
-				<then>
-					<property name="jtregTar" value="jtreg_7_3_1_1"/>
-				</then>
-			</elseif>
 			<else>
-				<fail message="Unsupported JDK version: ${JDK_VERSION}"/>
+				<property name="jtregTar" value="jtreg_7_3_1_1"/>
 			</else>
 		</if>
 


### PR DESCRIPTION
fixes: https://github.com/eclipse-openj9/openj9/issues/19435 