### PR TITLE
Correct jtreg_7.4+1 url

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -168,9 +168,9 @@ my %base = (
 		shaalg => '256'
 	},
 	jtreg_7_4_1 => {
-		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.4.1.tar.gz',
+		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.4+1.tar.gz',
 		fname => 'jtreg_7_4_1.tar.gz',
-		shaurl => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.4.1.tar.gz.sha256sum.txt',
+		shaurl => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.4+1.tar.gz.sha256sum.txt',
 		shafn => 'jtreg_7_4_1.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},


### PR DESCRIPTION
Fixes: https://github.com/adoptium/TKG/issues/575

Correct the dependency download url, which should match the openjdk/jtreg actual tag: [jtreg_7.4+1](https://github.com/openjdk/jtreg/releases/tag/jtreg-7.4%2B1)
