### PR TITLE
Fetch jars and shas from same location

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -340,10 +340,11 @@ if ($task eq "clean") {
 				$url_custom =~ s/test.getDependency/systemtest.getDependency/;
 				$url_custom .= "systemtest_prereqs/";
 				$url_custom .= $jars_info[$i]{dir};
-				$url_custom .= '/' unless $url_custom =~ /\/$/;
-				$url_custom .= $jars_info[$i]{fname};
-				$url = "$url_custom";
 			}
+
+			$url_custom .= '/' unless $url_custom =~ /\/$/;
+			$url_custom .= $jars_info[$i]{fname};
+			$url = "$url_custom";
 
 			if (defined $shaurl && $shaurl ne '') {
 				$shaurl = "$url_custom/$shafn";


### PR DESCRIPTION
If we are getting our third party dependent shas from a custom URL, then the jars should also come from the same location.