### PR TITLE
JavaInfo.java: accept osArch i386

### DIFF
--- a/src/org/openj9/envInfo/JavaInfo.java
+++ b/src/org/openj9/envInfo/JavaInfo.java
@@ -55,7 +55,7 @@ public class JavaInfo {
             return null;
         }
 
-        if (osArch.contains("amd64") || osArch.contains("x86")) {
+        if (osArch.contains("amd64") || osArch.contains("x86") || osArch.contains("i386")) {
             spec += "_x86";
         } else if (osArch.contains("ppc") || osArch.contains("powerpc")) {
             spec += "_ppc";


### PR DESCRIPTION
We face this error on linux x86:
```
...
System.getProperty('java.vm.name')=OpenJDK Server VM

System.getProperty('java.vendor')=Red Hat, Inc.

System.getProperty('os.name')=Linux

System.getProperty('os.arch')=i386

System.getProperty('java.fullversion')=null

Cannot determine System.getProperty('os.arch')=i386

make: *** [envDetect] Error 1
...
```



JavaInfo.java should accept `i386` of `os.arch` system property. Seems like value of `os.arch` can be `x86` or `i386` on intel 32-bit, depending on platform. (See also [code](https://github.com/openjdk/jdk8u-dev/blob/fc15e99a3218a88434c27da1d7d09a01c592d8f9/test/lib/jdk/test/lib/Platform.java#L245) in Platform test class.)