### PR TITLE
Add maven dependency

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -188,7 +188,7 @@ my %base = (
 		url => 'https://dlcdn.apache.org/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.tar.gz',
 		fname => 'apache-maven-bin.tar.gz',
 		shaurl => 'https://dlcdn.apache.org/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.tar.gz.sha512',
-		shafn => 'apache-maven-3.9.8-bin.tar.gz.sha512',
+		shafn => 'apache_maven_3.9.8_bin.tar.gz.sha512.txt',
 		shaalg => '512'
 	});
 

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -184,55 +184,10 @@ my %base = (
 		fname => 'jcstress-tests-all-20240222.jar',
 		sha1 => '200da75e67689e8a604ec6fe9a6f55b2c000b6ce'
 	},
-	hamcrest_core => {
-		url => 'https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar',
-		fname => 'hamcrest-core.jar',
-		sha1 => '42a25dc3219429f0e5d060061f71acb49bf010a0'
-	},
-	bcprov_jdk18on => {
-		url => 'https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.78.1/bcprov-jdk18on-1.78.1.jar',
-		fname => 'bcprov-jdk18on.jar',
-		sha1 => '39e9e45359e20998eb79c1828751f94a818d25f8'
-	},
-	bcpkix_jdk18on => {
-		url => 'https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk18on/1.78.1/bcpkix-jdk18on-1.78.1.jar',
-		fname => 'bcpkix-jdk18on.jar',
-		sha1 => '17b3541f736df97465f87d9f5b5dfa4991b37bb3'
-	},
-	bcprov_ext_jdk18on => {
-		url => 'https://repo1.maven.org/maven2/org/bouncycastle/bcprov-ext-jdk18on/1.78/bcprov-ext-jdk18on-1.78.jar',
-		fname => 'bcprov-ext-jdk18on.jar',
-		sha1 => 'ce389d6dee236dbf6aea7fb139e2745381c18882'
-	},
-	junit_vintage_engine => {
-		url => 'https://repo1.maven.org/maven2/org/junit/vintage/junit-vintage-engine/5.10.2/junit-vintage-engine-5.10.2.jar',
-		fname => 'junit-vintage-engine.jar',
-		sha1 => '2905387f99f86a6618d1f7c005e7a5946224f317'
-	},
-	junit_platform_suite => {
-		url => 'https://repo1.maven.org/maven2/org/junit/platform/junit-platform-suite/1.10.1/junit-platform-suite-1.10.1.jar',
-		fname => 'junit-platform-suite.jar',
-		sha1 => 'a219dbd79ec2b1fc61b806554fcf4eb5c17a6d1d'
-	},
-	junit_jupiter_api => {
-		url => 'https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-api/5.10.2/junit-jupiter-api-5.10.2.jar',
-		fname => 'junit-jupiter-api.jar',
-		sha1 => 'fb55d6e2bce173f35fd28422e7975539621055ef'
-	},
-	junit_jupiter_engine => {
-		url => 'https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.10.2/junit-jupiter-engine-5.10.2.jar',
-		fname => 'junit-jupiter-engine.jar',
-		sha1 => 'f1f8fe97bd58e85569205f071274d459c2c4f8cd'
-	},
-	junit_jupiter_params => {
-		url => 'https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-params/5.10.2/junit-jupiter-params-5.10.2.jar',
-		fname => 'junit-jupiter-params.jar',
-		sha1 => '359132c82a9d3fa87a325db6edd33b5fdc67a3d8'
-	},
-	junit_platform_suite_api => {
-		url => 'https://repo1.maven.org/maven2/org/junit/platform/junit-platform-suite-api/1.10.2/junit-platform-suite-api-1.10.2.jar',
-		fname => 'junit-platform-suite-api.jar',
-		sha1 => '174bba1574c37352b0eb2c06e02b6403738ad57c'
+	maven => {
+		url => 'https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz',
+		fname => 'apache-maven-bin.tar.gz',
+		sha512 => '706f01b20dec0305a822ab614d51f32b07ee11d0218175e55450242e49d2156386483b506b3a4e8a03ac8611bae96395fd5eec15f50d3013d5deed6d1ee18224'
 	});
 
 my %system_jars = (

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -188,7 +188,7 @@ my %base = (
 		url => 'https://dlcdn.apache.org/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.tar.gz',
 		fname => 'apache-maven-bin.tar.gz',
 		shaurl => 'https://dlcdn.apache.org/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.tar.gz.sha512',
-		shafn => 'apache_maven_3.9.8_bin.tar.gz.sha512.txt',
+		shafn => 'apache_maven_3.9.8_bin.tar.gz.sha512',
 		shaalg => '512'
 	});
 

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -187,9 +187,7 @@ my %base = (
 	maven => {
 		url => 'https://dlcdn.apache.org/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.tar.gz',
 		fname => 'apache-maven-bin.tar.gz',
-		shaurl => 'https://dlcdn.apache.org/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.tar.gz.sha512',
-		shafn => 'apache_maven_3.9.8_bin.tar.gz.sha512',
-		shaalg => '512'
+		sha1 => '7f15c63c129f036dd5c96b1a591ed8d888f75617'
 	});
 
 my %system_jars = (

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -185,9 +185,9 @@ my %base = (
 		sha1 => '200da75e67689e8a604ec6fe9a6f55b2c000b6ce'
 	},
 	maven => {
-		url => 'https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz',
+		url => 'https://dlcdn.apache.org/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.tar.gz',
 		fname => 'apache-maven-bin.tar.gz',
-		sha512 => '706f01b20dec0305a822ab614d51f32b07ee11d0218175e55450242e49d2156386483b506b3a4e8a03ac8611bae96395fd5eec15f50d3013d5deed6d1ee18224'
+		sha512 => '7d171def9b85846bf757a2cec94b7529371068a0670df14682447224e57983528e97a6d1b850327e4ca02b139abaab7fcb93c4315119e6f0ffb3f0cbc0d0b9a2'
 	});
 
 my %system_jars = (

--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -187,7 +187,9 @@ my %base = (
 	maven => {
 		url => 'https://dlcdn.apache.org/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.tar.gz',
 		fname => 'apache-maven-bin.tar.gz',
-		sha512 => '7d171def9b85846bf757a2cec94b7529371068a0670df14682447224e57983528e97a6d1b850327e4ca02b139abaab7fcb93c4315119e6f0ffb3f0cbc0d0b9a2'
+		shaurl => 'https://dlcdn.apache.org/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.tar.gz.sha512',
+		shafn => 'apache-maven-3.9.8-bin.tar.gz.sha512',
+		shaalg => '512'
 	});
 
 my %system_jars = (


### PR DESCRIPTION
This update adds maven as a dependency to build and test the OpenJCEPlus project. As part of this effort other dependencies that were used in the past for this project have been removed.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>
