### PR TITLE
Issue 5428: Allow JRE testing for other testsuite aside from JCK

### DIFF
--- a/settings.mk
+++ b/settings.mk
@@ -168,6 +168,11 @@ ifdef JRE_IMAGE
    JRE_COMMAND:=$(Q)$(JRE_IMAGE)$(D)bin$(D)java$(Q)
 endif
 
+JAVA_TO_TEST = $(JAVA_COMMAND)
+ifeq ($(USE_JRE),1)
+  JAVA_TO_TEST = $(JRE_COMMAND)
+endif
+
 #######################################
 # common dir and jars
 #######################################


### PR DESCRIPTION
move JAVA_TO_TEST to the TKG settings.mk
https://github.com/adoptium/aqa-tests/issues/5428