### PR TITLE
Removed _xl for mac platform in TRSS query

### DIFF
--- a/src/org/testKitGen/TestDivider.java
+++ b/src/org/testKitGen/TestDivider.java
@@ -225,8 +225,11 @@ public class TestDivider {
 		String group = getGroup();
 		String level = getLevel();
 		Map<String, Integer> map = new HashMap<String, Integer>();
-		String URL = constructURL(impl, plat, group, level);
 		String osName = System.getProperty("os.name").toLowerCase();
+		if (osName.contains("mac")) {
+			plat = plat.replace("_xl", "");
+		}
+		String URL = constructURL(impl, plat, group, level);
 		String command;
 
 		if (osName.contains("win")) {


### PR DESCRIPTION
- The platform for aarch64_mac should not include _xl in TRSS url when querying for test execution times,
- Adjusted the code to remove _xl from the platform string if the OS is macOS.

related: https://github.com/adoptium/TKG/issues/557