### PR TITLE
Changing tag of jar files to BINARY

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -464,6 +464,8 @@ sub downloadFile {
 	# note _ENCODE_FILE_NEW flag is set for zos
 	if ('.txt' eq substr $filename, -length('.txt')) {
 		$output = qx{_ENCODE_FILE_NEW=ISO8859-1 curl $curlOpts -k -o $filename $url 2>&1};
+	} elsif ('.jar' eq substr $filename, -length('.jar')) {
+		$output = qx{_ENCODE_FILE_NEW=BINARY curl $curlOpts -k -o $filename $url 2>&1};
 	} else {
 		$output = qx{_ENCODE_FILE_NEW=UNTAGGED curl $curlOpts -k -o $filename $url 2>&1};
 	}


### PR DESCRIPTION
This PR changes file tagging of testDependency *.jar files from IBM-1047 to BINARY. This PR fixes #600 