### PR TITLE
Remove IBM-1047 export option and generate makefiles in IBM-1047 encoding for JDK21 on z/OS

### DIFF
--- a/makefile
+++ b/makefile
@@ -38,16 +38,8 @@ endif
 
 UNAME := uname
 UNAME_OS := $(shell $(UNAME) -s | cut -f1 -d_)
-$(info UNAME_OS is $(UNAME_OS))
 ifeq ($(findstring CYGWIN,$(UNAME_OS)), CYGWIN)
 	LIB_DIR:=$(shell cygpath -w $(LIB_DIR))
-else ifeq ($(UNAME_OS),OS/390)
-# The issue is still being investigated. See backlog/issues/1424
-# set -Dfile.encoding=IBM-1047 for JDK21+ zOS for now
-ifeq ($(shell test $(JDK_VERSION) -ge 21; echo $$?),0)
-export IBM_JAVA_OPTIONS="-Dfile.encoding=IBM-1047"
-$(info export IBM_JAVA_OPTIONS="-Dfile.encoding=IBM-1047")
-endif
 endif
 
 export LIB_DIR:=$(subst \,/,$(LIB_DIR))

--- a/src/org/openj9/envInfo/EnvDetector.java
+++ b/src/org/openj9/envInfo/EnvDetector.java
@@ -14,10 +14,8 @@
 
 package org.openj9.envInfo;
 
-import java.io.FileOutputStream;
-import java.io.OutputStreamWriter;
 import java.io.IOException;
-import java.io.BufferedWriter;
+import java.io.Writer;
 
 public class EnvDetector {
 	static boolean isMachineInfo = false;
@@ -80,9 +78,9 @@ public class EnvDetector {
 		/**
 		 * autoGenEnv.mk file will be created to store auto detected java info.
 		 */
-		BufferedWriter output = null;
+		Writer output = null;
 		try {
-			output = new BufferedWriter(new OutputStreamWriter(new FileOutputStream("autoGenEnv.mk")));
+			output = Utility.getWriterObject(javaVersionInfo, SPECInfo, "autoGenEnv.mk");
 			output.write("########################################################\n");
 			output.write("# This is an auto generated file. Please do NOT modify!\n");
 			output.write("########################################################\n");
@@ -94,7 +92,7 @@ public class EnvDetector {
 			output.write(JDK_VENDOR);
 			output.write(TEST_FLAG);
 			output.close();
-			output = new BufferedWriter(new OutputStreamWriter(new FileOutputStream("AQACert.log")));
+			output = Utility.getWriterObject(javaVersionInfo, SPECInfo, "AQACert.log");
 			output.write(JAVA_VERSION);
 			output.write(RELEASE_INFO);
 			output.close();

--- a/src/org/openj9/envInfo/Utility.java
+++ b/src/org/openj9/envInfo/Utility.java
@@ -1,0 +1,27 @@
+package org.openj9.envInfo;
+
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
+
+public class Utility {
+
+    public static Writer writer;
+
+    public static Writer getWriterObject(int jdkVersion, String SpecInfo, String fileName) {
+		try {
+			if (SpecInfo.toLowerCase().contains("zos") && (jdkVersion >= 21)) {
+				writer = new OutputStreamWriter(new FileOutputStream(fileName, true), Charset.forName("IBM-1047"));
+			} else {
+				writer = new FileWriter(fileName, true);
+			}
+		} catch(IOException e) {
+			e.printStackTrace();
+			System.exit(1);
+		}
+		return writer;
+	}
+}

--- a/src/org/testKitGen/MkGen.java
+++ b/src/org/testKitGen/MkGen.java
@@ -14,14 +14,18 @@
 
 package org.testKitGen;
 
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.openj9.envInfo.JavaInfo;
+import org.openj9.envInfo.Utility;
+
 public class MkGen {
 	private Arguments arg;
+	private JavaInfo jInfo;
 	private TestTarget tt;
 	private List<String> dirList;
 	private List<String> subdirs;
@@ -30,6 +34,7 @@ public class MkGen {
 
 	public MkGen(Arguments arg, TestTarget tt, PlaylistInfo pli, String makeFile, List<String> dirList, List<String> subdirs) {
 		this.arg = arg;
+		this.jInfo = new JavaInfo();
 		this.tt = tt;
 		this.dirList = dirList;
 		this.subdirs = subdirs;
@@ -46,7 +51,7 @@ public class MkGen {
 	}
 
 	private void writeVars() {
-		try (FileWriter f = new FileWriter(makeFile)) {
+		try (Writer f = Utility.getWriterObject(jInfo.getJDKVersion(), arg.getSpec(), makeFile)) {
 			String realtiveRoot = "";
 			int subdirlevel = dirList.size();
 			if (subdirlevel == 0) {
@@ -72,7 +77,7 @@ public class MkGen {
 		}
 	}
 
-	private void writeSingleTest(List<String> testsInPlaylist, TestInfo testInfo, FileWriter f) throws IOException {
+	private void writeSingleTest(List<String> testsInPlaylist, TestInfo testInfo, Writer f) throws IOException {
 		for (Variation var : testInfo.getVars()) {
 			// Generate make target
 			String testTargetName = var.getSubTestName();
@@ -227,7 +232,7 @@ public class MkGen {
 	}
 
 	private void writeTargets() {
-		try (FileWriter f = new FileWriter(makeFile, true)) {
+		try (Writer f = Utility.getWriterObject(jInfo.getJDKVersion(), arg.getSpec(), makeFile)) {
 			if (!pli.getIncludeList().isEmpty()) {
 				for (String include : pli.getIncludeList()) {
 					f.write("-include " + include + "\n\n");

--- a/src/org/testKitGen/ModesDictionary.java
+++ b/src/org/testKitGen/ModesDictionary.java
@@ -29,12 +29,14 @@ import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.openj9.envInfo.JavaInfo;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 public class ModesDictionary {
 	private Arguments arg;
+	private JavaInfo jInfo;
 	private String modesXml;
 	private String ottawaCsv;
 	private Map<String, String> spec2platMap;
@@ -44,6 +46,7 @@ public class ModesDictionary {
 
 	public ModesDictionary(Arguments arg) {
 		this.arg = arg;
+		jInfo = new JavaInfo();
 		modesXml= arg.getProjectRootDir() + "/TKG/" + Constants.MODESXML;
 		ottawaCsv = arg.getProjectRootDir() + "/TKG/" + Constants.OTTAWACSV;
 		spec2platMap = new HashMap<String, String>();
@@ -98,7 +101,7 @@ public class ModesDictionary {
 		ArrayList<String> specs = new ArrayList<String>();
 		int lineNum = 0;
 		BufferedReader reader = null;
-		if (arg.getSpec().toLowerCase().contains("zos") && !(arg.getJdkVersion().matches("[2-9][0-9]"))) {
+		if (arg.getSpec().toLowerCase().contains("zos") && !(jInfo.getJDKVersion() >= 21)) {
 			reader = Files.newBufferedReader(Paths.get(ottawaCsv), Charset.forName("IBM-1047"));
 		} else {
 			reader = Files.newBufferedReader(Paths.get(ottawaCsv));

--- a/src/org/testKitGen/ModesDictionary.java
+++ b/src/org/testKitGen/ModesDictionary.java
@@ -98,7 +98,7 @@ public class ModesDictionary {
 		ArrayList<String> specs = new ArrayList<String>();
 		int lineNum = 0;
 		BufferedReader reader = null;
-		if (arg.getSpec().toLowerCase().contains("zos")) {
+		if (arg.getSpec().toLowerCase().contains("zos") && !(arg.getJdkVersion().matches("[2-9][0-9]"))) {
 			reader = Files.newBufferedReader(Paths.get(ottawaCsv), Charset.forName("IBM-1047"));
 		} else {
 			reader = Files.newBufferedReader(Paths.get(ottawaCsv));

--- a/src/org/testKitGen/UtilsGen.java
+++ b/src/org/testKitGen/UtilsGen.java
@@ -15,13 +15,18 @@
 package org.testKitGen;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.List;
+
+import org.openj9.envInfo.JavaInfo;
+import org.openj9.envInfo.Utility;
+
 
 public class UtilsGen {
 	private Arguments arg;
 	private ModesDictionary md;
+	private JavaInfo jInfo;
 	private String utilsMk;
 	private String rerunMk;
 	private List<String> ignoreOnRerunList;
@@ -29,6 +34,7 @@ public class UtilsGen {
 	public UtilsGen(Arguments arg, ModesDictionary md, List<String> ignoreOnRerunList) {
 		this.arg = arg;
 		this.md = md;
+		this.jInfo = new JavaInfo();
 		this.utilsMk = arg.getProjectRootDir() + "/TKG/" + Constants.UTILSMK;
 		this.rerunMk = arg.getProjectRootDir() + "/TKG/" + Constants.RERUNMK;
 		this.ignoreOnRerunList = ignoreOnRerunList;
@@ -40,7 +46,7 @@ public class UtilsGen {
 	}
 
 	private void generateUtil() {
-		try (FileWriter f = new FileWriter(utilsMk)) {
+		try (Writer f = Utility.getWriterObject(jInfo.getJDKVersion(), arg.getSpec(), utilsMk)) {
 			f.write(Constants.HEADERCOMMENTS);
 			f.write("TOTALCOUNT := " + TestInfo.numOfTests() + "\n");
 			f.write("PLATFORM=\n");
@@ -56,7 +62,7 @@ public class UtilsGen {
 	}
 
 	private void generateRerun() {
-		try (FileWriter f = new FileWriter(rerunMk)) {
+		try (Writer f = Utility.getWriterObject(jInfo.getJDKVersion(), arg.getSpec(), rerunMk)) {
 			f.write(Constants.HEADERCOMMENTS);
 			String ignoreOnRerunStr = String.join(",", ignoreOnRerunList);
 			f.write("IGNORE_ON_RERUN=");


### PR DESCRIPTION
This PR reverts below commit which exports `IBM_JAVA_OPTIONS to IBM-1047`, as this option isn't required anymore. JDK21 z/OS latest builds works fine without any options.
https://github.com/psoujany/TKG/commit/28c7f761d9d2e60043930c1d699ad79c72c2a29c

defaultCharset of Java21 is UTF-8, TKG scripts which are generating makefiles like utils.mk, rerun.mk are getting created in UTF for 21 on z/OS causing encoding issues. Hence, changing scripts to forcefully create these makefiles in `Charset.forName("IBM-1047")` only for 21 on z/OS.
