### PR TITLE
Ignore variations when JVM_OPTIONS is set

### DIFF
--- a/src/org/testKitGen/TestInfoParser.java
+++ b/src/org/testKitGen/TestInfoParser.java
@@ -155,6 +155,8 @@ public class TestInfoParser {
 				Variation var = parseVariation(subTestName, variations.get(i), ti.getPlatform(), ti.getPlatformRequirementsList());
 				listOfVars.add(var);
 			}
+		} else {
+			System.out.println("Warning: JVM_OPTIONS specified, ignoring variations for " + testCaseName + ".");
 		}
 		if (variations.size() == 0) {
 			String subTestName = ti.getTestCaseName() + "_0";

--- a/src/org/testKitGen/TestInfoParser.java
+++ b/src/org/testKitGen/TestInfoParser.java
@@ -147,12 +147,14 @@ public class TestInfoParser {
 		getElements(ti.getPlatformRequirementsList(), "platformRequirementsList", "platformRequirements", null, ti.getTestCaseName());
 
 		List<String> variations = new ArrayList<String>();
-		getElements(variations, "variations", "variation", null, ti.getTestCaseName());
 		List<Variation> listOfVars = new ArrayList<Variation>();
-		for (int i = 0; i < variations.size(); i++) {
-			String subTestName = ti.getTestCaseName() + "_" + i;
-			Variation var = parseVariation(subTestName, variations.get(i), ti.getPlatform(), ti.getPlatformRequirementsList());
-			listOfVars.add(var);
+		if (System.getenv("JVM_OPTIONS") == null) {
+			getElements(variations, "variations", "variation", null, ti.getTestCaseName());
+			for (int i = 0; i < variations.size(); i++) {
+				String subTestName = ti.getTestCaseName() + "_" + i;
+				Variation var = parseVariation(subTestName, variations.get(i), ti.getPlatform(), ti.getPlatformRequirementsList());
+				listOfVars.add(var);
+			}
 		}
 		if (variations.size() == 0) {
 			String subTestName = ti.getTestCaseName() + "_0";


### PR DESCRIPTION
This changeset causes variations from `playlist.xml` to be ignored, if `JVM_OPTIONS` env. variable is set. See also: https://github.com/adoptium/TKG/issues/611

**Motivation:**
If `JVM_OPTIONS` env. var is set, jvm opstions for test target get overwritten (including ones set by variation). In this case, test target is still repeated for every variation. However variations no longer make any sense (with overwritten JVM options). It just causes confusion and makes test target run longer.

**Testing:**
with `JVM_OPTIONS` set: [OK](https://ci.adoptium.net/job/Grinder/10879/) (multiple variations are NOT ran)
without `JVM_OPTIONS` set: [OK](https://ci.adoptium.net/job/Grinder/10880/) (multiple variations are ran)
