### PR TITLE
Support multiple required in features tag

### DIFF
--- a/scripts/testTKG/test_platformRequirements.py
+++ b/scripts/testTKG/test_platformRequirements.py
@@ -149,6 +149,7 @@ def run_test():
 			skipped.add('test_not_arch_390_0')
 	else:
 		passed.add('test_not_arch_390_0')
+		passed.add('test_not_arch_390_z15plus_0')
 
 	if 'test_arch_390_z15_0' not in passed:
 		skipped.add('test_arch_390_z15_0')

--- a/src/org/testKitGen/TestInfoParser.java
+++ b/src/org/testKitGen/TestInfoParser.java
@@ -88,11 +88,15 @@ public class TestInfoParser {
 			ti.addFeature(featElements[0].toLowerCase(), featElements[1].toLowerCase());
 		}
 		Set<String> testFlags = new HashSet<>(arg.getTestFlag());
+		boolean requiredFeatureFound = false;
+		boolean hasRequiredFeature = false; 
 		for (Map.Entry<String,String> entry : ti.getFeatures().entrySet()) {
 			String featureOpt = entry.getValue().toLowerCase();
 			if (featureOpt.equals("required")) {
-				if (!isFeatureInTestFlags(testFlags, entry.getKey())) {
-					return null;
+				hasRequiredFeature = true;
+				if (isFeatureInTestFlags(testFlags, entry.getKey())) {
+					requiredFeatureFound = true;
+					break;
 				}
 			} else if (featureOpt.equals("nonapplicable")) {
 				// Do not generate make target if the test is not applicable for one feature defined in TEST_FLAG
@@ -106,7 +110,9 @@ public class TestInfoParser {
 				System.exit(1);
 			}
 		}
-
+		if (hasRequiredFeature && !requiredFeatureFound) {
+			return null;
+		}
 		if (testFlags.contains("aot")) {
 			for (Map.Entry<String,String> entry : ti.getFeatures().entrySet()) {
 				if (doesFeatureMatchTestFlag("aot", entry.getKey())) {


### PR DESCRIPTION
- Removed `null` statement from `required` feature check to ensure all required features are processed.
- Allows the code to continue checking all feature flags, even after finding a required flag in `testFlags`.

related:https://github.ibm.com/runtimes/backlog/issues/1525