### PR TITLE
Remove tools.jar dependency from TKG

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -248,12 +248,6 @@ my %system_jars = (
 		dir => 'mauve',
 		fname => 'mauve.jar',
 		is_system_test => 1
-	},
-	tools => {
-		url => 'https://ci.adoptium.net/job/systemtest.getDependency/lastSuccessfulBuild/artifact/systemtest_prereqs/tools/tools.jar',
-		dir => 'tools',
-		fname => 'tools.jar',
-		is_system_test => 1
 	});
 
 my %jars_to_use;


### PR DESCRIPTION
This PR removes the `tools.jar` dependency from TKG due to the following updates in related repositories:
- **aqa-tests:** Updated to use JDK 17 (instead of JDK 8) to build system test-related jars ([PR 5711](https://github.com/adoptium/aqa-tests/pull/5711)).
- **STF**: Modified to use `tools.jar` from the `java.home/lib` directory ([adoptium/STF#140](https://github.com/adoptium/STF/pull/140)).

related: eclipse-openj9/openj9#19888
