### PR TITLE
Enhance the check of envTf variable

### DIFF
--- a/src/org/openj9/envInfo/JavaInfo.java
+++ b/src/org/openj9/envInfo/JavaInfo.java
@@ -259,7 +259,7 @@ public class JavaInfo {
         checkJFR();
         String envTf = System.getenv("TEST_FLAG");
         String paddedTf = null;
-        if (envTf != null) {
+        if (envTf != null && !envTf.isEmpty()) {
             testFlag = envTf;
             paddedTf =  "," + envTf + ",";
         }


### PR DESCRIPTION
Similar to #640 with jenkins docker pull images, envTf could be an empty string. 