### PR TITLE
Use jtreg6.1 for JDK11/17 on z/OS

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -167,6 +167,13 @@ my %base = (
 		shafn => 'jtreg_7_3_1_1.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
+	jtreg_6_1 => {
+		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-6+1.tar.gz',
+		fname => 'jtreg_6_1.tar.gz',
+		shaurl => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-6+1.tar.gz.sha256sum.txt',
+		shafn => 'jtreg_6_1.tar.gz.sha256sum.txt',
+		shaalg => '256'
+	},
 	jtreg_7_4_1 => {
 		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.4+1.tar.gz',
 		fname => 'jtreg_7_4_1.tar.gz',

--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -21,12 +21,25 @@
 	<!-- set default LIB property to all -->
 	<property name="LIB" value="all"/>
 	<target name="getJtregVersion">
+		<condition property="jtregOnZ">
+			<and>
+				<contains string="${SPEC}" substring="zos"/>
+				<matches pattern="^(11|17)$" string="${JDK_VERSION}"/>
+			</and>
+		</condition>
 		<if>
 			<!-- versions 8-10, 12-16 -->
 			<matches pattern="^([89]|1[02-6])$" string="${JDK_VERSION}"/>
 			<then>
 				<property name="jtregTar" value="jtreg_5_1_b01"/>
 			</then>
+			<elseif>
+				<!-- versions 11, 17 on z/OS -->
+				<isset property="jtregOnZ"/>
+				<then>
+					<property name="jtregTar" value="jtreg_6_1"/>
+				</then>
+			</elseif>
 			<elseif>
 				<!-- versions 11, 17-23 -->
 				<matches pattern="^(11|1[7-9]|2[0-3])$" string="${JDK_VERSION}"/>
@@ -39,6 +52,7 @@
 				<property name="jtregTar" value="jtreg_7_4_1"/>
 			</else>
 		</if>
+		<echo message="jtreg version used is : ${jtregTar}"/>
 
 		<if>
 			<or>

--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -34,7 +34,10 @@
 				<property name="jtregTar" value="jtreg_5_1_b01"/>
 			</then>
 			<elseif>
-				<!-- versions 11, 17 on z/OS -->
+				<!-- 
+				# versions 11,17 on z/OS need to use jtreg6.1, due to encoding issues with jtreg7.*.
+				# For more details, refer openj9-openjdk-jdk17-zos/issues/928.
+				-->
 				<isset property="jtregOnZ"/>
 				<then>
 					<property name="jtregTar" value="jtreg_6_1"/>


### PR DESCRIPTION
This PR to make JDK11 and JDK17 openjdk tests to use jtreg6.1 on z/OS. jtreg7.* has encoding issues on z/OS which led to Malformed Input Error with JDK11 and JDK17 on z/OS.