### PR TITLE
Generate parallelList and buildInfo makefiles in ebcdic for JDK21 on z/OS

### DIFF
--- a/src/org/testKitGen/BuildList.java
+++ b/src/org/testKitGen/BuildList.java
@@ -15,21 +15,26 @@
 package org.testKitGen;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.openj9.envInfo.JavaInfo;
+import org.openj9.envInfo.Utility;
+
 public class BuildList {
 	private Arguments arg;
+	private JavaInfo jInfo;
 	private Set<String> originalSet = new HashSet<>();
 	private Set<String> newSet = new HashSet<>();
 	private String buildInfomk;
 
 	public BuildList(Arguments arg) {
 		this.arg = arg;
+		this.jInfo = new JavaInfo();
 		buildInfomk = arg.getProjectRootDir() + "/TKG/" + Constants.BUILDINFOMK;
 		initializeSet();
 	}
@@ -92,7 +97,7 @@ public class BuildList {
 	}
 
 	public void generateList() {
-		try (FileWriter f = new FileWriter(buildInfomk)) {
+		try (Writer f = Utility.getWriterObject(jInfo.getJDKVersion(), arg.getSpec(), buildInfomk)) {
 			f.write(Constants.HEADERCOMMENTS);
 			f.write("REFINED_BUILD_LIST := " + getStr() + "\n");
 			System.out.println("Generated " + buildInfomk + "\n");

--- a/src/org/testKitGen/ModesDictionary.java
+++ b/src/org/testKitGen/ModesDictionary.java
@@ -101,7 +101,7 @@ public class ModesDictionary {
 		ArrayList<String> specs = new ArrayList<String>();
 		int lineNum = 0;
 		BufferedReader reader = null;
-		if (arg.getSpec().toLowerCase().contains("zos") && !(arg.getJdkVersion().matches("[2-9][0-9]"))) {
+		if (arg.getSpec().toLowerCase().contains("zos") && !(jInfo.getJDKVersion() >= 21)) {
 			reader = Files.newBufferedReader(Paths.get(ottawaCsv), Charset.forName("IBM-1047"));
 		} else {
 			reader = Files.newBufferedReader(Paths.get(ottawaCsv));

--- a/src/org/testKitGen/ModesDictionary.java
+++ b/src/org/testKitGen/ModesDictionary.java
@@ -101,7 +101,7 @@ public class ModesDictionary {
 		ArrayList<String> specs = new ArrayList<String>();
 		int lineNum = 0;
 		BufferedReader reader = null;
-		if (arg.getSpec().toLowerCase().contains("zos") && !(jInfo.getJDKVersion() >= 21)) {
+		if (arg.getSpec().toLowerCase().contains("zos") && !(arg.getJdkVersion().matches("[2-9][0-9]"))) {
 			reader = Files.newBufferedReader(Paths.get(ottawaCsv), Charset.forName("IBM-1047"));
 		} else {
 			reader = Files.newBufferedReader(Paths.get(ottawaCsv));

--- a/src/org/testKitGen/TestDivider.java
+++ b/src/org/testKitGen/TestDivider.java
@@ -15,7 +15,6 @@
 package org.testKitGen;
 
 import java.io.FileFilter;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.File;
 import java.util.*;
@@ -25,13 +24,18 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.FileReader;
+import java.io.Writer;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
+import org.openj9.envInfo.JavaInfo;
+import org.openj9.envInfo.Utility;
+
 public class TestDivider {
 	private Arguments arg;
+	private JavaInfo jInfo;
 	private TestTarget tt;
 	private List<String> testsToExecute;
 	private List<String> testsToDisplay;
@@ -41,6 +45,7 @@ public class TestDivider {
 
 	public TestDivider(Arguments arg, TestTarget tt) {
 		this.arg = arg;
+		this.jInfo = new JavaInfo();
 		this.tt = tt;
 		testsToExecute = TestInfo.getTestsToExecute();
 		testsToDisplay = TestInfo.getTestsToDisplay();
@@ -350,7 +355,7 @@ public class TestDivider {
 
 	private void writeParallelmk(List<List<String>> parallelLists) {
 		try {
-			FileWriter f = new FileWriter(parallelmk);
+			Writer f = Utility.getWriterObject(jInfo.getJDKVersion(), arg.getSpec(),parallelmk);
 			f.write(Constants.HEADERCOMMENTS);
 			f.write("NUM_LIST=" + parallelLists.size() + "\n\n");
 			for (int i = 0; i < parallelLists.size(); i++) {


### PR DESCRIPTION
This PR is extension of https://github.com/adoptium/TKG/pull/608 to convert parallelList and buildInfo makefiles in ebcdic for JDK21 on z/OS.