### PR TITLE
Fix tests for empty strings in _setup

### DIFF
--- a/settings.mk
+++ b/settings.mk
@@ -380,19 +380,12 @@ setup_%: testEnvSetup
 	@$(ECHO) set JDK_IMPL to $(JDK_IMPL)
 	@$(ECHO) set JVM_VERSION to $(JVM_VERSION)
 	@$(ECHO) set JCL_VERSION to $(JCL_VERSION)
-	@if [ $(OLD_JAVA_HOME) ]; then \
-		$(ECHO) JAVA_HOME was originally set to $(OLD_JAVA_HOME); \
-	fi
+	@$(if $(OLD_JAVA_HOME),$(ECHO) JAVA_HOME was originally set to $(OLD_JAVA_HOME))
 	@$(ECHO) set JAVA_HOME to $(JAVA_HOME)
 	@$(ECHO) set SPEC to $(SPEC)
 	@$(ECHO) set TEST_FLAG to $(TEST_FLAG)
-	@if [ $(MICROARCH) ]; then \
-		$(ECHO) set MICROARCH to $(MICROARCH); \
-	fi
-	@if [ $(OS_LABEL) ]; then \
-		$(ECHO) set OS_LABEL to $(OS_LABEL); \
-	fi
-
+	@$(if $(MICROARCH),$(ECHO) set MICROARCH to $(MICROARCH))
+	@$(if $(OS_LABEL),$(ECHO) set OS_LABEL to $(OS_LABEL))
 	@$(MKTREE) $(Q)$(TESTOUTPUT)$(Q)
 	@$(CP) $(Q)$(TEST_ROOT)$(D)TKG$(D)SHAs.txt$(Q) $(Q)$(TESTOUTPUT)$(D)$(Q)
 	@$(ECHO) Running $(TESTTARGET) ...


### PR DESCRIPTION
If a macro like `OLD_JAVA_HOME` expands to nothing, the resulting command (`if [ ]; then` ...) is considered syntactically invalid by some versions of bash. This avoids that problem by letting make evaluate the test by using `$(if)`.

See sample failure in https://openj9-jenkins.osuosl.org/job/Test_openjdk8_j9_sanity.functional_x86-32_windows_Personal_testList_0/236/console
```
13:19:07  Running make 4.3
13:19:07  set TEST_ROOT to C:/Users/jenkins/workspace/Test_openjdk8_j9_sanity.functional_x86-32_windows_Personal_testList_0/aqa-tests/
13:19:07  set JDK_VERSION to 8
13:19:07  set JDK_IMPL to openj9
13:19:07  set JVM_VERSION to openjdk8-openj9
13:19:07  set JCL_VERSION to latest
13:19:07  /bin/sh: -c: line 3: syntax error: unexpected end of file
13:19:07  make[2]: *** [settings.mk:383: setup_testList] Error 1
13:19:07  make[2]: Leaving directory '/cygdrive/c/Users/jenkins/workspace/Test_openjdk8_j9_sanity.functional_x86-32_windows_Personal_testList_0/aqa-tests/TKG'
13:19:07  make[1]: *** [makefile:74: _testList] Error 2
13:19:07  make[1]: Leaving directory '/cygdrive/c/Users/jenkins/workspace/Test_openjdk8_j9_sanity.functional_x86-32_windows_Personal_testList_0/aqa-tests/TKG'
13:19:07  make: *** [parallelList.mk:8: testList_0] Error 2
```