### PR TITLE
Update references to SHA.txt -> SHAs.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ tempTestTargetResult
 failedtargets.mk
 autoGenEnv.mk
 buildInfo.mk
-SHA.txt
+SHAs.txt
 
 .DS_Store
 

--- a/scripts/getSHAs.sh
+++ b/scripts/getSHAs.sh
@@ -22,7 +22,6 @@ usage ()
 	echo 'Usage : '
 	echo '                --test_root_dir: optional'
 	echo '                --shas_file: optional, the file to write the sha info to. Default is to ../SHAs.txt'
-
 }
 
 parseCommandLineArgs()
@@ -50,8 +49,9 @@ parseCommandLineArgs()
 	fi
 }
 
-timestamp() {
-  date +"%Y%m%d-%H%M%S"
+timestamp()
+{
+	date +"%Y%m%d-%H%M%S"
 }
 
 getSHAs()
@@ -70,7 +70,7 @@ getSHAs()
 		{ echo "================================================"; echo "timestamp: $(timestamp)"; echo "repo dir: $repoDir"; echo "git repo: "; git remote show origin -n | grep "Fetch URL:"; echo "sha:"; git rev-parse HEAD; }  2>&1 | tee -a "$SHAs_FILE"
 	done
 }
+
 parseCommandLineArgs "$@"
 getSHAs
 cd "$workDIR" || exit
-

--- a/scripts/getTestenvProperties.sh
+++ b/scripts/getTestenvProperties.sh
@@ -17,18 +17,16 @@ OUTPUT_FILE="../testenv.properties"
 REPO_NAME=""
 REPO_SHA=""
 
-
 usage ()
 {
 	echo 'This script use git command to get sha in the provided REPO_DIR HEAD and write the info into the OUTPUT_FILE'
 	echo 'Usage : '
 	echo '                --repo_dir: local git repo dir'
-	echo '                --output_file: the file to write the sha info to. Default is to ../SHA.txt'
+	echo '                --output_file: the file to write the sha info to. Default is to ../SHAs.txt'
 	echo '                --repo_name: git repo name. It will be used as a parameter name in testenv.properties'
 	echo '                --repo_sha: git repo sha. If this value is not provided, use git command to get the repo sha. Otherwise, use the provided sha.'
 	echo '                USE_TESTENV_PROPERTIES: env variable. If set to false, regenerate testenv.properties to capture the repo and sha. Otherwise, do nothing. The existing testenv.properties file will be used.'
 	echo '                JDK_IMPL: env variable. Only used for openjdk tests. If JDK_IMPL = openj9, append OPENJ9 in REPO_NAME for openjdk repo . i.e., JDK11_OPENJ9. Otherwise, REPO_NAME is unchanged.'
-
 }
 
 parseCommandLineArgs()
@@ -62,7 +60,8 @@ parseCommandLineArgs()
 	fi
 }
 
-getTestenvProperties() {
+getTestenvProperties()
+{
 	if [[ "$USE_TESTENV_PROPERTIES" != true  ]]; then
 		echo "Check sha in $REPO_DIR and store the info in $OUTPUT_FILE"
 		if [ ! -e ${OUTPUT_FILE} ]; then


### PR DESCRIPTION
Hashes are now captured in `SHAs.txt` instead of `SHA.txt`.

Fix nearby formatting inconsistencies.