### PR TITLE
Also download jtreg-7.5+1 and use for Java 25+

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -181,6 +181,13 @@ my %base = (
 		shafn => 'jtreg_7_4_1.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
+	jtreg_7_5_1 => {
+		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5+1.tar.gz',
+		fname => 'jtreg_7_5_1.tar.gz',
+		shaurl => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5+1.tar.gz.sha256sum.txt',
+		shafn => 'jtreg_7_5_1.tar.gz.sha256sum.txt',
+		shaalg => '256'
+	},
 	jython => {
 		url => 'https://repo1.maven.org/maven2/org/python/jython-standalone/2.7.2/jython-standalone-2.7.2.jar',
 		fname => 'jython-standalone.jar',

--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -50,9 +50,16 @@
 					<property name="jtregTar" value="jtreg_7_3_1_1"/>
 				</then>
 			</elseif>
+			<elseif>
+				<!-- version 24 -->
+				<matches pattern="^24$" string="${JDK_VERSION}"/>
+				<then>
+					<property name="jtregTar" value="jtreg_7_4_1"/>
+				</then>
+			</elseif>
 			<else>
-				<!-- versions 24+ -->
-				<property name="jtregTar" value="jtreg_7_4_1"/>
+				<!-- versions 25+ -->
+				<property name="jtregTar" value="jtreg_7_5_1"/>
 			</else>
 		</if>
 		<echo message="jtreg version used is : ${jtregTar}"/>


### PR DESCRIPTION
See [8339238: Update to use jtreg 7.5.1](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/f644a9511ae32adbbeff77b211f82b8d42bdd62d).