### PR TITLE
Also download jtreg-7.5.1+1 and use for Java 25+

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -181,11 +181,11 @@ my %base = (
 		shafn => 'jtreg_7_4_1.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
-	jtreg_7_5_1 => {
-		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5+1.tar.gz',
-		fname => 'jtreg_7_5_1.tar.gz',
-		shaurl => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5+1.tar.gz.sha256sum.txt',
-		shafn => 'jtreg_7_5_1.tar.gz.sha256sum.txt',
+	jtreg_7_5_1_1 => {
+		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5.1+1.tar.gz',
+		fname => 'jtreg_7_5_1_1.tar.gz',
+		shaurl => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.5.1+1.tar.gz.sha256sum.txt',
+		shafn => 'jtreg_7_5_1_1.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
 	jython => {

--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -59,7 +59,7 @@
 			</elseif>
 			<else>
 				<!-- versions 25+ -->
-				<property name="jtregTar" value="jtreg_7_5_1"/>
+				<property name="jtregTar" value="jtreg_7_5_1_1"/>
 			</else>
 		</if>
 		<echo message="jtreg version used is : ${jtregTar}"/>


### PR DESCRIPTION
Corrects #673, which should have used 7.5.1+1 instead of 7.5+1; see [8339238: Update to use jtreg 7.5.1](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/f644a9511ae32adbbeff77b211f82b8d42bdd62d).

Depends on https://github.com/adoptium/ci-jenkins-pipelines/pull/1202.