### PR TITLE
Correct post test Perl resultsSum processing to correctly handle commas and Test Results line

### DIFF
--- a/scripts/resultsSum.pl
+++ b/scripts/resultsSum.pl
@@ -148,7 +148,8 @@ sub resultReporter {
 						$endTime = $1;
 						$tapString .= "    duration_ms: " . ($endTime - $startTime) . "\n  ...\n";
 						last;
-					} elsif ($result =~  /(Test results: .*)(passed|skipped|failed|error)(: .*\d{1,}$)/) {
+					} elsif ($result =~ /(Test results: .*)(passed|skipped|failed|error)/) {
+						# We have the Test results line
 						$testCasesPerTargetSummary = $result;
 						chomp($testCasesPerTargetSummary);
 						push (@testCasesResults, $result);					
@@ -200,7 +201,8 @@ sub resultReporter {
 							if ($buildList =~ /openjdk/) {
 								for my $i (0 .. $#lines) {
 									if ( $lines[$i] =~ /[-]{50}/) {
-										if ( ($lines[$i+1] =~ /(TEST: )(.*?)(\.java|\.sh|#.*)$/) || ($lines[$i+1] =~ /(Test results: .*)(failed|error)(: \d{1,}$)/) ) {
+										if ( ($lines[$i+1] =~ /(TEST: )(.*?)(\.java|\.sh|#.*)$/) || ($lines[$i+1] =~ /(Test results: .*)(failed|error)/) ) {
+											# We have a failed TEST: line, or we have the Test results line containing failed|error
 											$i++;
 											$failureTests .= $lines[$i] . "\n";
 										}
@@ -211,11 +213,13 @@ sub resultReporter {
 								for my $i (0 .. $#lines) {
 									$lines[$i] =~ s/^\s+|\s+$//g; 
 									if ( $lines[$i] =~ /(.*?)(\.html|#.*)(.*?)(Failed|Error\.)(.*?)/) {
+										# We have a jck testcase result line with Failed|Error in it
 										my @testsInfo = split(/\s+/, $lines[$i]);
 										my $testName = $testsInfo[0];
 										$testName =~ s/#.*//;
 										$failureTests .= '        ' ."TEST: " . $testName . "\n";
-									} elsif ( $lines[$i] =~  /(Test results: .*)(skipped|failed|error)(: \d{1,}$)/) {
+									} elsif ( $lines[$i] =~ /(Test results: .*)(failed|error)/) {
+										# We have the Test results line containing failed|error
 										$testResult = $lines[$i];
 									}
 								}


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/6081

Improve resultsSum.pl to recognise openjdk or jck Test results lines.
Some of the regex's were not allowing for ",", and were unnecessarily trying to group the (numeric) value, when just recoginising the error|failed is all that was needed.

Test builds:
TC/job/Test_openjdk24_hs_extended.jck_aarch64_mac/22/console - SUCCESSFUL test result summary and tap file content, and failed tests ReRun
extended.openjdk test: https://ci.adoptium.net/view/Test_openjdk/job/Test_openjdk21_hs_extended.openjdk_aarch64_linux/133/ - SUCCESSFUL test result summary and tap file content
