### PR TITLE
Preserve encoding and tags while copying files on z/OS

### DIFF
--- a/scripts/build_test.xml
+++ b/scripts/build_test.xml
@@ -97,13 +97,24 @@
 	</target>
 
 	<target name="stage_test_material" depends="-create_test_directory">
-		<copy todir="${ascii.test.dir}">
-			<fileset dir="${ascii.workspace.dir}">
-				<include name="TKG/**" />
-				<include name="*.mk" />
-			</fileset>
-		</copy>
-
+		<if>
+			<equals arg1="${os.name}" arg2="z/OS" />
+			<then>
+				<exec executable="cp" failonerror="true">
+					<arg value="-rf" />
+					<arg value="${ascii.workspace.dir}" />
+					<arg value="${ascii.test.dir}" />
+				</exec>
+			</then>
+			<else>
+				<copy todir="${ascii.test.dir}">
+					<fileset dir="${ascii.workspace.dir}">
+						<include name="TKG/**" />
+						<include name="*.mk" />
+					</fileset>
+				</copy>
+			</else>
+		</if>
 		<chmod dir="${ascii.test.dir}/TKG" perm="755"/>
 
 		<chmod file="${ascii.test.dir}/*.mk" perm="755"/>


### PR DESCRIPTION
This PR fixes https://github.ibm.com/runtimes/openj9-openjdk-jdk21-zos/pull/713#issuecomment-111565653 and https://github.ibm.com/runtimes/openj9-openjdk-jdk21-zos/issues/720