### PR TITLE
Set JCL_VERSION to latest except for IBM Java8

### DIFF
--- a/settings.mk
+++ b/settings.mk
@@ -404,6 +404,8 @@ ifndef JCL_VERSION
 ifeq (ibm, $(JDK_IMPL))
 ifeq (8,$(JDK_VERSION))
 export JCL_VERSION:=current
+else
+export JCL_VERSION:=latest
 endif
 else
 export JCL_VERSION:=latest


### PR DESCRIPTION
related: [internal issue](https://github.ibm.com/runtimes/openj9-openjdk-jdk21-zos/pull/732#issuecomment-113719145)