### PR TITLE
Use jtreg_8_2(latest jtreg version) on z/OS across JDK11/17 releases

### DIFF
--- a/scripts/getDependencies.pl
+++ b/scripts/getDependencies.pl
@@ -167,13 +167,6 @@ my %base = (
 		shafn => 'jtreg_7_3_1_1.tar.gz.sha256sum.txt',
 		shaalg => '256'
 	},
-	jtreg_6_1 => {
-		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-6+1.tar.gz',
-		fname => 'jtreg_6_1.tar.gz',
-		shaurl => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-6+1.tar.gz.sha256sum.txt',
-		shafn => 'jtreg_6_1.tar.gz.sha256sum.txt',
-		shaalg => '256'
-	},
 	jtreg_7_4_1 => {
 		url => 'https://ci.adoptium.net/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/jtreg-7.4+1.tar.gz',
 		fname => 'jtreg_7_4_1.tar.gz',

--- a/scripts/getDependencies.xml
+++ b/scripts/getDependencies.xml
@@ -35,12 +35,12 @@
 			</then>
 			<elseif>
 				<!-- 
-				# versions 11,17 on z/OS need to use jtreg6.1, due to encoding issues with jtreg7.*.
+				# versions 11,17 on z/OS need to use jtreg8_2 which uses defaultCharste() to parse TEST.group files.
 				# For more details, refer openj9-openjdk-jdk17-zos/issues/928.
 				-->
 				<isset property="jtregOnZ"/>
 				<then>
-					<property name="jtregTar" value="jtreg_6_1"/>
+					<property name="jtregTar" value="jtreg_8_2"/>
 				</then>
 			</elseif>
 			<elseif>


### PR DESCRIPTION
As part of this issue openj9-openjdk-jdk17-zos/issues/928, we made changes to jtreg code(https://github.com/openjdk/jtreg/pull/267) use defaultCharset() while parsing Test.group files on z/OS. This PR is part of below jtreg archive which we want to use on z/OS for  11/17 releases so that to we use default workspaces.
